### PR TITLE
[MJAVADOC-512] - Even when <javadocVersion>1.8.0</javadocVersion> matches there still is a warning.

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -3782,7 +3782,7 @@ public abstract class AbstractJavadocMojo
                 throw new MavenReportException( "Unable to parse javadoc version: " + e.getMessage(), e );
             }
 
-            if ( javadocRuntimeVersion != jVersion && getLog().isWarnEnabled() )
+            if ( javadocRuntimeVersion.compareTo( jVersion ) != 0 && getLog().isWarnEnabled() )
             {
                 getLog().warn( "Are you sure about the <javadocVersion/> parameter? It seems to be " + jVersion );
             }


### PR DESCRIPTION
Even when `<javadocVersion>1.8.0</javadocVersion>` matches there still is the following log message:

> [WARNING] Are you sure about the <javadocVersion/> parameter? It seems to be 1.8.0.