### PR TITLE
[MJAVADOC-444] add aggregate-no-fork and aggregate-test-no-fork for non-forking versions of aggregate goals.

### DIFF
--- a/src/it/projects/MJAVADOC-444/invoker.properties
+++ b/src/it/projects/MJAVADOC-444/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=clean verify site

--- a/src/it/projects/MJAVADOC-444/moduleA/pom.xml
+++ b/src/it/projects/MJAVADOC-444/moduleA/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
+    <artifactId>mjavadoc-444</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>mjavadoc-444-moduleA</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/projects/MJAVADOC-444/moduleA/src/main/java/com/mycompany/myapp/AppA.java
+++ b/src/it/projects/MJAVADOC-444/moduleA/src/main/java/com/mycompany/myapp/AppA.java
@@ -1,0 +1,31 @@
+package com.mycompany.myapp;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Hello world!
+ */
+public class AppA
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/src/it/projects/MJAVADOC-444/moduleA/src/test/java/com/mycompany/myapp/AppATest.java
+++ b/src/it/projects/MJAVADOC-444/moduleA/src/test/java/com/mycompany/myapp/AppATest.java
@@ -1,0 +1,57 @@
+package com.mycompany.myapp;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppATest
+    extends TestCase
+{
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public AppATest( String testName )
+    {
+        super( testName );
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite()
+    {
+        return new TestSuite( AppATest.class );
+    }
+
+    /**
+     * Rigourous Test :-)
+     */
+    public void testApp()
+    {
+        assertTrue( true );
+    }
+}

--- a/src/it/projects/MJAVADOC-444/moduleB/pom.xml
+++ b/src/it/projects/MJAVADOC-444/moduleB/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
+    <artifactId>mjavadoc-444</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>mjavadoc-444-moduleB</artifactId>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/projects/MJAVADOC-444/moduleB/src/main/java/com/mycompany/myapp/AppB.java
+++ b/src/it/projects/MJAVADOC-444/moduleB/src/main/java/com/mycompany/myapp/AppB.java
@@ -1,0 +1,31 @@
+package com.mycompany.myapp;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Hello world!
+ */
+public class AppB
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+}

--- a/src/it/projects/MJAVADOC-444/moduleB/src/test/java/com/mycompany/myapp/AppBTest.java
+++ b/src/it/projects/MJAVADOC-444/moduleB/src/test/java/com/mycompany/myapp/AppBTest.java
@@ -1,0 +1,57 @@
+package com.mycompany.myapp;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppBTest
+    extends TestCase
+{
+    /**
+     * Create the test case
+     *
+     * @param testName name of the test case
+     */
+    public AppBTest( String testName )
+    {
+        super( testName );
+    }
+
+    /**
+     * @return the suite of tests being tested
+     */
+    public static Test suite()
+    {
+        return new TestSuite( AppBTest.class );
+    }
+
+    /**
+     * Rigourous Test :-)
+     */
+    public void testApp()
+    {
+        assertTrue( true );
+    }
+}

--- a/src/it/projects/MJAVADOC-444/pom.xml
+++ b/src/it/projects/MJAVADOC-444/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
+  <artifactId>mjavadoc-444</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>myapp</name>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <modules>
+    <module>moduleA</module>
+    <module>moduleB</module>
+  </modules>
+
+  <build>
+    <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>1.3.1</version>
+          <executions>
+            <execution>
+              <id>default-enforce</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <alwaysPass/>
+                </rules>
+                <fail>true</fail>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>@pom.version@</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>@sitePluginVersion@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <reporting>
+    <excludeDefaults>true</excludeDefaults>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>@pom.version@</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>aggregate-no-fork</report>
+              <report>test-aggregate-no-fork</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
+</project>

--- a/src/it/projects/MJAVADOC-444/verify.bsh
+++ b/src/it/projects/MJAVADOC-444/verify.bsh
@@ -1,0 +1,40 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+File indexFile = new File( basedir, "target/site/apidocs/index.html" );
+
+if ( !indexFile.exists() )
+{
+    System.err.println( indexFile.getAbsolutePath() + " is missing." );
+    return false;
+}
+
+File buildLog = new File( basedir, "build.log" );
+String content = IOUtil.toString( new FileInputStream( buildLog ) );
+String needle = ">>> maven-javadoc-plugin";
+if ( content.contains( needle ) )
+{
+    System.err.println( "build.log contains '" + needle + "'" );
+    return false;
+}
+return true;

--- a/src/main/java/org/apache/maven/plugins/javadoc/AggregatorJavadocNoForkReport.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AggregatorJavadocNoForkReport.java
@@ -1,0 +1,39 @@
+package org.apache.maven.plugins.javadoc;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * Generates documentation for the <code>Java code</code> in an <b>aggregator</b> project using the standard
+ * <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/javadoc/">Javadoc Tool</a>.
+ *
+ * @version $Id$
+ * @since 3.0.1
+ */
+@Mojo( name = "aggregate-no-fork", requiresDependencyResolution = ResolutionScope.COMPILE )
+@Execute( phase = LifecyclePhase.NONE )
+public class AggregatorJavadocNoForkReport
+    extends AggregatorJavadocReport
+{
+}

--- a/src/main/java/org/apache/maven/plugins/javadoc/AggregatorTestJavadocNoForkReport.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AggregatorTestJavadocNoForkReport.java
@@ -1,0 +1,39 @@
+package org.apache.maven.plugins.javadoc;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * Generates documentation for the <code>Java Test code</code> in an <b>aggregator</b> project using the standard
+ * <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/javadoc/">Javadoc Tool</a>.
+ *
+ * @version $Id$
+ * @since 3.0.1
+ */
+@Mojo( name = "test-aggregate-no-fork", requiresDependencyResolution = ResolutionScope.TEST )
+@Execute( phase = LifecyclePhase.NONE )
+public class AggregatorTestJavadocNoForkReport
+    extends AggregatorTestJavadocReport
+{
+}

--- a/src/site/apt/examples/aggregate-nofork.apt.vm
+++ b/src/site/apt/examples/aggregate-nofork.apt.vm
@@ -1,9 +1,5 @@
  ------
- Generate Javadoc without duplicate execution of phase generate-sources.
- ------
- Mirko Friedenhagen
- ------
- 2014-03-19
+ Generate aggregate Javadoc without duplicate execution of phase compile.
  ------
 
 ~~ Licensed to the Apache Software Foundation (ASF) under one
@@ -26,21 +22,19 @@
 ~~ NOTE: For help with the syntax of this file, see:
 ~~ http://maven.apache.org/doxia/references/apt-format.html
 
-Generate Javadoc without duplicate execution of phase generate-sources.
+Generate aggregate Javadoc without duplicate execution of phase compile.
 
- * The standard goals <<<javadoc>>> and <<<test-javadoc>>> invoke separate lifecyles
- <<<generate-sources>>> and <<<generate-test-sources>>>.
+ * The standard goals <<<aggregate>>> and <<<test-aggregate>>> invoke separate lifecyles
+ <<<compile>>> and <<<test-compile>>>.
 
  * In a CI environment you now might execute something like <<<mvn clean deploy site site-deploy>>>.
 
- * During <<<site>>> build the standard reports will trigger <<<generate-sources>>> or
- <<<generate-test-sources>>> again, depending on your build this may take some time, because
+ * During <<<site>>> build the standard reports will trigger <<<compile>>> or
+ <<<test-compile>>> again, depending on your build this may take some time, because
  stuff like <<<enforcer>>> or generating stubs from a WDSL will be invoked again, which may lead
  to longer build times.
 
- * See {{{https://issues.apache.org/jira/browse/MJAVADOC-369}MJAVADOC-369}} as well.
-
- * As of version 2.10 two new reports are defined, <<<javadoc-no-fork>>> and <<<test-javadoc-no-fork>>>
+ * As of version 3.0.1 two new reports are defined, <<<aggregate-no-fork>>> and <<<test-aggregate-no-fork>>>
  which will not trigger above phases a second time.
 
  * Configure this in your <<<reporting>>> section as follows:
@@ -58,8 +52,8 @@ Generate Javadoc without duplicate execution of phase generate-sources.
         <reportSets>
           <reportSet>
             <reports>
-              <report>javadoc-no-fork</report>
-              <report>test-javadoc-no-fork</report>
+              <report>aggregate-no-fork</report>
+              <report>test-aggregate-no-fork</report>
             </reports>
           </reportSet>
         </reportSets>
@@ -69,6 +63,3 @@ Generate Javadoc without duplicate execution of phase generate-sources.
   ...
 </project>
 +-----+
-
- <<Note>>: These reports may not be used for aggregate reports. For those, see the example of
-     {{{./aggregate-nofork.html}generating aggregate Javadocs without execution of phase compile}}.

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -49,7 +49,7 @@ javadoc.exe(or .sh) @options @packages | @argfile
 
 * Goals Overview
 
-   The Javadoc Plugin has 14 goals:
+   The Javadoc Plugin has 16 goals:
 
    * {{{./javadoc-mojo.html}javadoc:javadoc}} generates the Javadoc files for the project. It executes the standard
      Javadoc tool and supports the parameters used by the tool.
@@ -58,12 +58,12 @@ javadoc.exe(or .sh) @options @packages | @argfile
      the standard Javadoc tool and supports the parameters used by the tool.
 
    * {{{./javadoc-no-fork-mojo.html}javadoc:javadoc-no-fork}} generates the Javadoc files for the project.
-     It executes the standard Javadoc tool and supports the parameters used by the tool without forking the 
+     It executes the standard Javadoc tool and supports the parameters used by the tool without forking the
      <<<generate-sources>>> phase again. Note that this goal does require generation of test sources before site generation, e.g.
      by invoking <<<mvn clean deploy site>>>.
 
-   * {{{./test-javadoc-no-fork-mojo.html}javadoc:test-javadoc-no-fork}} generates the test Javadoc files for the project. 
-     It executes the standard Javadoc tool and supports the parameters used by the tool without forking the 
+   * {{{./test-javadoc-no-fork-mojo.html}javadoc:test-javadoc-no-fork}} generates the test Javadoc files for the project.
+     It executes the standard Javadoc tool and supports the parameters used by the tool without forking the
      <<<generate-test-sources>>> phase again. Note that this goal does require generation of test sources before site generation,
      e.g. by invoking <<<mvn clean deploy site>>>.
 
@@ -72,6 +72,16 @@ javadoc.exe(or .sh) @options @packages | @argfile
 
    * {{{./test-aggregate-mojo.html}javadoc:test-aggregate}} generates the test Javadoc files for an aggregator project.
      It executes the standard Javadoc tool and supports the parameters used by the tool.
+
+   * {{{./aggregate-no-fork-mojo.html}javadoc:aggregate-no-fork}} generates the Javadoc files for an aggregator project.
+     It executes the standard Javadoc tool and supports the parameters used by the tool without forking the <<compile>>>
+     phase again. Note that this goal does require generation of class files before site generation, e.g. by invoking
+     <<<mvn compile>>> or <<<mvn install>>>.
+
+   * {{{./test-aggregate-no-fork-mojo.html}javadoc:test-aggregate}} generates the test Javadoc files for an aggregator
+     project. It executes the standard Javadoc tool and supports the parameters used by the tool without forking the
+     <<<compile>>> phase again. Note that this goal does require generation of test class files before site generation,
+     e.g. by invoking <<<mvn test-compile>>> or <<<mvn install>>>.
 
    * {{{./jar-mojo.html}javadoc:jar}} creates an archive file of the generated Javadocs. It is used during
      the release process to create the Javadoc artifact for the project's release.  This artifact is uploaded
@@ -154,5 +164,7 @@ javadoc.exe(or .sh) @options @packages | @argfile
    * {{{./examples/fix-javadocs.html}Fixing Javadoc Comments}}
 
    * {{{./examples/javadoc-nofork.html}Generate Javadoc without duplicate execution of phase generate-sources}}
+
+   * {{{./examples/aggregate-nofork.html}Generate aggregate Javadocs without execution of phase compile}}
 
    []

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -55,6 +55,7 @@ under the License.
       <item name="Fixing Javadoc Comments" href="/examples/fix-javadocs.html"/>
       <item name="Adding additional dependencies" href="/examples/additional-dependencies.html"/>
       <item name="Generate Javadoc without duplicate execution of phase generate-sources" href="/examples/javadoc-nofork.html"/>
+      <item name="Generate aggregate Javadoc without duplicate execution of phase compile" href="/examples/aggregate-nofork.html"/>
     </menu>
   </body>
 </project>


### PR DESCRIPTION

Follows the same pattern as JavadocNoForkReport with the aggregate goals.

Tested out locally by installing a SNAPSHOT version and then moving my project over to it.