### PR TITLE
[MJAVADOC-537] Explicitly the batchMode to true

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
@@ -920,6 +920,7 @@ public class JavadocUtil
         InvocationRequest request = new DefaultInvocationRequest();
         request.setBaseDirectory( projectFile.getParentFile() );
         request.setPomFile( projectFile );
+        request.setBatchMode( true );
         if ( log != null )
         {
             request.setDebug( log.isDebugEnabled() );


### PR DESCRIPTION
To prevent a warning about a missing input stream we explicitly set
batchMode when invoking other maven commands

fixes MJAVADOC-537