### PR TITLE
[MJAVADOC-544] - Changed behaviour of Javadoc for temporary files encoding (options, argfile, ...)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,9 @@ under the License.
     <contributor>
       <name>Kevin Risden</name>
     </contributor>
+    <contributor>
+      <name>Michael Stumpf</name>
+    </contributor>
   </contributors>
 
   <dependencies>

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -108,6 +108,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -4374,9 +4375,15 @@ public abstract class AbstractJavadocMojo
         options.append( StringUtils.join( arguments.iterator(),
                                           SystemUtils.LINE_SEPARATOR ) );
 
+        /* default to platform encoding */
+        String outputFileEncoding = null;
+        if ( JAVA_VERSION.isAtLeast( "9" ) )
+        {
+            outputFileEncoding = StandardCharsets.UTF_8.name();
+        }
         try
         {
-            FileUtils.fileWrite( optionsFile.getAbsolutePath(), null /* platform encoding */, options.toString() );
+            FileUtils.fileWrite( optionsFile.getAbsolutePath(), outputFileEncoding, options.toString() );
         }
         catch ( IOException e )
         {

--- a/src/test/java/org/apache/maven/plugins/javadoc/stubs/OptionsUmlautEncodingMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/javadoc/stubs/OptionsUmlautEncodingMavenProjectStub.java
@@ -1,0 +1,80 @@
+package org.apache.maven.plugins.javadoc.stubs;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
+import org.apache.maven.model.Scm;
+import org.apache.maven.model.Build;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.io.File;
+
+public class OptionsUmlautEncodingMavenProjectStub
+    extends MavenProjectStub
+{
+   private Scm scm;
+
+    public OptionsUmlautEncodingMavenProjectStub()
+    {
+        readModel( new File( getBasedir(), "optionsumlautencoding-test-plugin-config.xml" ) );
+
+        setGroupId( "org.apache.maven.plugins.maven-javadoc-plugin.unit" );
+        setArtifactId( "optionsumlautencoding-test" );
+        setVersion( "1.0-SNAPSHOT" );
+        setName( "Maven Javadoc Plugin Options Umlaut Encoding Test" );
+        setUrl( "http://maven.apache.org" );
+        setPackaging( "jar" );
+
+        Scm scm = new Scm();
+        scm.setConnection( "scm:svn:http://svn.apache.org/maven/sample/trunk" );
+        setScm( scm );
+
+        Build build = new Build();
+        build.setFinalName( "optionsumlautencoding-test" );
+        build.setDirectory( super.getBasedir() + "/target/test/unit/optionsumlautencoding-test/target" );
+        setBuild( build );
+
+        List<String> compileSourceRoots = new ArrayList<>();
+        compileSourceRoots.add( getBasedir() + "/optionsumlautencoding/test" );
+        setCompileSourceRoots( compileSourceRoots );
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Scm getScm()
+    {
+        return scm;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setScm( Scm scm )
+    {
+        this.scm = scm;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public File getBasedir()
+    {
+        return new File( super.getBasedir() + "/src/test/resources/unit/optionsumlautencoding-test" );
+    }
+}

--- a/src/test/resources/unit/optionsumlautencoding-test/optionsumlautencoding-test-plugin-config.xml
+++ b/src/test/resources/unit/optionsumlautencoding-test/optionsumlautencoding-test-plugin-config.xml
@@ -1,0 +1,73 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.unit</groupId>
+  <artifactId>optionsumlautencoding-test</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <inceptionYear>2006</inceptionYear>
+  <name>Maven Javadoc Plugin Options Umlaut Encoding Test</name>
+  <url>http://maven.apache.org</url>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <project implementation="org.apache.maven.plugins.javadoc.stubs.OptionsUmlautEncodingMavenProjectStub"/>
+          <localRepository>${localRepository}</localRepository>
+          <outputDirectory>${basedir}/target/test/unit/optionsumlautencoding-test/target/site/apidocs</outputDirectory>
+          <javadocOptionsDir>${basedir}/target/test/unit/optionsumlautencoding-test/target/javadoc-bundle-options</javadocOptionsDir>
+          <breakiterator>false</breakiterator>
+          <old>false</old>
+          <show>protected</show>
+          <quiet>true</quiet>
+          <verbose>false</verbose>
+          <author>true</author>
+          <encoding>ISO-8859-1</encoding>
+          <docfilessubdirs>false</docfilessubdirs>
+          <linksource>false</linksource>
+          <nocomment>false</nocomment>
+          <nodeprecated>false</nodeprecated>
+          <nodeprecatedlist>false</nodeprecatedlist>
+          <nohelp>false</nohelp>
+          <noindex>false</noindex>
+          <nonavbar>false</nonavbar>
+          <nosince>false</nosince>
+          <notree>false</notree>
+          <serialwarn>false</serialwarn>
+          <splitindex>false</splitindex>
+          <stylesheet>java</stylesheet>
+          <groups/>
+          <tags/>
+          <use>true</use>
+          <version>true</version>
+          <!-- include umlauts in windowtitle which are written to options-file -->
+          <windowtitle>Maven Javadoc Plugin Options Umlaut Encoding ö ä ü ß Test 1.0-SNAPSHOT API</windowtitle>
+          <debug>true</debug>
+          <failOnError>true</failOnError>
+          <detectJavaApiLink>true</detectJavaApiLink>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/optionsumlautencoding-test/optionsumlautencoding/test/App.java
+++ b/src/test/resources/unit/optionsumlautencoding-test/optionsumlautencoding/test/App.java
@@ -1,0 +1,36 @@
+package optionsumlautencoding.test;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class App
+{
+
+    public static void main( String[] args )
+    {
+        System.out.println( "Sample Application." );
+    }
+
+
+    protected void sampleMethod( String str )
+    {
+        System.out.println( str );
+    }
+
+}

--- a/src/test/resources/unit/optionsumlautencoding-test/optionsumlautencoding/test/AppSample.java
+++ b/src/test/resources/unit/optionsumlautencoding-test/optionsumlautencoding/test/AppSample.java
@@ -1,0 +1,39 @@
+package optionsumlautencoding.test;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @author Maria Odea Ching
+ * @since 1.4
+ * @version %I%, %G%
+ */
+public class AppSample
+{
+
+    /**
+     * The main method
+     *
+     * @param args  an array of strings that contains the arguments
+     */
+    public static void main( String[] args )
+    {
+        System.out.println( "Another Sample Application" );
+    }
+}


### PR DESCRIPTION
mvn -Prun-its verify was run with JDK9 on windows without errors