### PR TITLE
[MJAVADOC-538] Filter out 'Picked up'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,9 @@ under the License.
     <contributor>
       <name>Anton Klarén</name>
     </contributor>
+    <contributor>
+      <name>Kevin Risden</name>
+    </contributor>
   </contributors>
 
   <dependencies>
@@ -441,6 +444,8 @@ under the License.
               </filterProperties>
               <environmentVariables>
                 <JENKINS_MAVEN_AGENT_DISABLED>true</JENKINS_MAVEN_AGENT_DISABLED>
+                <!-- required for MJAVADOC-538 -->
+                <_JAVA_OPTIONS>-Dabc=def</_JAVA_OPTIONS>
               </environmentVariables>
             </configuration>
           </plugin>

--- a/src/it/projects/MJAVADOC-538/invoker.properties
+++ b/src/it/projects/MJAVADOC-538/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=clean javadoc:javadoc

--- a/src/it/projects/MJAVADOC-538/pom.xml
+++ b/src/it/projects/MJAVADOC-538/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
+  <artifactId>mjavadoc-538</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <url>https://issues.apache.org/jira/browse/MJAVADOC-538</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>@project.version@</version>
+          <configuration>
+            <failOnWarnings>true</failOnWarnings>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/it/projects/MJAVADOC-538/src/main/java/foo/bar/MyClass.java
+++ b/src/it/projects/MJAVADOC-538/src/main/java/foo/bar/MyClass.java
@@ -1,0 +1,24 @@
+package foo.bar;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class MyClass
+{
+}

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -5251,8 +5251,8 @@ public abstract class AbstractJavadocMojo
             writeDebugJavadocScript( cmdLine, javadocOutputDirectory );
         }
 
-        CommandLineUtils.StringStreamConsumer err = new CommandLineUtils.StringStreamConsumer();
-        CommandLineUtils.StringStreamConsumer out = new CommandLineUtils.StringStreamConsumer();
+        CommandLineUtils.StringStreamConsumer err = new JavadocUtil.JavadocOutputStreamConsumer();
+        CommandLineUtils.StringStreamConsumer out = new JavadocUtil.JavadocOutputStreamConsumer();
         try
         {
             int exitCode = CommandLineUtils.executeCommandLine( cmd, out, err );

--- a/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
@@ -1501,7 +1501,7 @@ public class JavadocUtil
      * @author Robert Scholte
      * @since 3.0.1
      */
-    private static class JavadocOutputStreamConsumer
+    protected static class JavadocOutputStreamConsumer
         extends CommandLineUtils.StringStreamConsumer
     {
         @Override


### PR DESCRIPTION
Tested with:
* `mvn -Prun-its verify`

Additional testing on project I was having original issues
* `mvn install`
* `export JAVA_TOOL_OPTIONS="-Dapple.awt.UIElement=true"`
* Set pom for project to use 3.0.2-SNAPSHOT
```
<pluginManagement>
  <plugins>
    <plugin>
      <groupId>org.apache.maven.plugins</groupId>
      <artifactId>maven-javadoc-plugin</artifactId>
      <version>3.0.2-SNAPSHOT</version>
    </plugin>
  </plugins>
</pluginManagement>
```
* Ran the following on my project - `mvn -Dmaven.javadoc.failOnError=true -Dmaven.javadoc.failOnWarnings=true javadoc:javadoc javadoc:test-javadoc`

Prior to this change was getting failure from warning "Picked up ...". With this change, Javadoc no longer fails due to warning.