### PR TITLE
[MJAVADOC-577] Fixed typos in User Guide.

### DIFF
--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -143,7 +143,7 @@ mvn javadoc:test-aggregate-jar
       </plugin>
     </plugins>
   </reporting>
-  </build>
+</project>
 +-----+
 
  [<<<mvn site>>>] It will generate the Javadoc for public members (defined in \<reporting/\>) using the given


### PR DESCRIPTION
I have modified the Wrong closing tag in the user's guide at 'https://maven.apache.org/plugins/maven-javadoc-plugin/usage.html'.

ticket : https://issues.apache.org/jira/browse/MJAVADOC-577

thank you for reading.
 