### PR TITLE
MJAVADOC-580: javadoc:javadoc detects wrong java API link when running on openjdk 11.0.2

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -6249,7 +6249,8 @@ public abstract class AbstractJavadocMojo
         }
         else if ( javaApiversion.isAtLeast( "11" ) )
         {
-            javaApiLink = String.format( "https://docs.oracle.com/en/java/javase/%s/docs/api/", javaApiversion );
+            javaApiLink = String.format( "https://docs.oracle.com/en/java/javase/%s/docs/api/",
+                javaApiversion.getValue( 1 ) );
         }
         else if ( javaApiversion.asMajor().isAtLeast( "6" ) )
         {


### PR DESCRIPTION
**Analysis:**
`AbstractJavadocMojo.setFJavadocVersion(File)` computes `javadocRuntimeVersion` variable by invoking `<javadocExecutable>`, which returns "11.0.2".
Neither `maven-javadoc-plugin<release>` nor `maven-compiler-plugin<source>` configuration is specified.
So `AbstractJavadocMojo.getDefaultJavadocApiLink()` formats Java API URL based on `javadocRuntimeVersion` variable, but it doesn't strip out $MINOR and $SECURITY segments of the version (i.e. "x.z" numbers in "y.x.z")

**Solution:**
One possible solution is to format URL based on $MAJOR number only.
One issue with this approach is that according to JEP 223 minor release can also have revisions in the API. This means, we could have 11.2.0 release in the future which this approach won't handle properly.
From this point of view the solution is to  format URL based on $MAJOR.MINOR numbers. 
What is unknown to me is whether Oracle would publish Java doc site for _every_ minor release, even if no changes in the API are introduced. We wouldn't like to generate URL for non existing Java API javadoc site.
Please let me know what you think.

Links: 
- http://openjdk.java.net/jeps/223


 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)