### PR TITLE
[MJAVADOC-616] Fix bug in JavadocReportTest.testOptionsUmlautEncoding when run on Java 8 or older

### DIFF
--- a/src/test/java/org/apache/maven/plugins/javadoc/JavadocReportTest.java
+++ b/src/test/java/org/apache/maven/plugins/javadoc/JavadocReportTest.java
@@ -69,7 +69,10 @@ import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
 public class JavadocReportTest
     extends AbstractMojoTestCase
 {
+
     private static final char LINE_SEPARATOR = ' ';
+
+    public static final String OPTIONS_UMLAUT_ENCODING_Ö_Ä_Ü_ß = "Options Umlaut Encoding ö ä ü ß";
 
     /** flag to copy repo only one time */
     private static boolean TEST_REPO_CREATED = false;
@@ -561,6 +564,7 @@ public class JavadocReportTest
 
         // check for a part of the window title
         String content;
+        String expected = OPTIONS_UMLAUT_ENCODING_Ö_Ä_Ü_ß;
         if ( JavaVersion.JAVA_VERSION.isAtLeast( "9" ) )
         {
             content = readFile( optionsFile, StandardCharsets.UTF_8 );
@@ -568,8 +572,10 @@ public class JavadocReportTest
         else
         {
             content = readFile( optionsFile, Charset.defaultCharset() );
+            expected = new String(expected.getBytes(Charset.defaultCharset()));
         }
-        assertTrue( content.contains( "Options Umlaut Encoding ö ä ü ß" ) );
+
+        assertTrue( content.contains(expected) );
 
         File apidocs = new File( getBasedir(), "target/test/unit/optionsumlautencoding-test/target/site/apidocs" );
 


### PR DESCRIPTION
Signed-off-by: Doychin Bondzhev <doychin@dsoft-bg.com>

The fix converts the expected umlaut string to local encoding (usually umlauts are converted to ? in this case) before assert is tested. 

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJAVADOC) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).