### PR TITLE
[MJAVADOC-620] Do not ignore JARs w/o module info when building classpath

### DIFF
--- a/src/it/projects/MJAVADOC-620_no-dot-in-version/invoker.properties
+++ b/src/it/projects/MJAVADOC-620_no-dot-in-version/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals.1 = -f maven-MJAVADOC620-jar install
+
+invoker.goals.2 = javadoc:aggregate

--- a/src/it/projects/MJAVADOC-620_no-dot-in-version/maven-MJAVADOC620-jar/pom.xml
+++ b/src/it/projects/MJAVADOC-620_no-dot-in-version/maven-MJAVADOC620-jar/pom.xml
@@ -1,0 +1,27 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
+  <artifactId>maven-MJAVADOC620-jar</artifactId>
+  <version>1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+</project>

--- a/src/it/projects/MJAVADOC-620_no-dot-in-version/maven-MJAVADOC620-jar/src/main/java/somepackage/Test.java
+++ b/src/it/projects/MJAVADOC-620_no-dot-in-version/maven-MJAVADOC620-jar/src/main/java/somepackage/Test.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package somepackage;
+
+/**
+ * Sample top-level class that is packaged into a non-module JAR.
+ */
+public class Test
+{
+}

--- a/src/it/projects/MJAVADOC-620_no-dot-in-version/pom.xml
+++ b/src/it/projects/MJAVADOC-620_no-dot-in-version/pom.xml
@@ -1,0 +1,52 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
+  <artifactId>maven-MJAVADOC-620-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Maven MJAVADOC-620 Test</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
+      <artifactId>maven-MJAVADOC620-jar</artifactId>
+      <version>1-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/projects/MJAVADOC-620_no-dot-in-version/src/main/java/TestUsage.java
+++ b/src/it/projects/MJAVADOC-620_no-dot-in-version/src/main/java/TestUsage.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import somepackage.Test;
+
+/**
+ * Sample class that tries to use top-level class from a non-module JAR.
+ */
+public class TestUsage
+{
+    /**
+     * Sample method that uses the top-level Test class from the other project.
+     */
+    public Test getTest()
+    {
+        return new Test();
+    }
+}

--- a/src/it/projects/MJAVADOC-620_no-dot-in-version/verify.bsh
+++ b/src/it/projects/MJAVADOC-620_no-dot-in-version/verify.bsh
@@ -1,0 +1,63 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+boolean result = true;
+
+try
+{
+    File target = new File( basedir, "target" );
+    if ( !target.exists() || !target.isDirectory() )
+    {
+        System.err.println( "target file is missing or not a directory." );
+        return false;
+    }
+
+    File apidocs = new File( basedir, "target/site/apidocs" );
+    if ( !apidocs.exists() || !apidocs.isDirectory() )
+    {
+        System.err.println( "target/site/apidocs file is missing or not a directory." );
+        return false;
+    }
+
+    File options = new File( apidocs, "options" );
+    if ( !options.exists() || !options.isFile() )
+    {
+        System.err.println( "target/site/apidocs/options file is missing or not a file." );
+        return false;
+    }
+
+    String str = FileUtils.fileRead( options );
+
+    if ( !str.contains( "maven-MJAVADOC620-jar-1-SNAPSHOT.jar" ) )
+    {
+        System.err.println( "Javadoc doesn't use correct artifacts." );
+        return false;
+    }
+}
+catch( IOException e )
+{
+    e.printStackTrace();
+    result = false;
+}
+
+return result;

--- a/src/it/projects/MJAVADOC-620_top-level-package/invoker.properties
+++ b/src/it/projects/MJAVADOC-620_top-level-package/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals.1 = -f maven-MJAVADOC620-jar install
+
+invoker.goals.2 = javadoc:aggregate

--- a/src/it/projects/MJAVADOC-620_top-level-package/maven-MJAVADOC620-jar/pom.xml
+++ b/src/it/projects/MJAVADOC-620_top-level-package/maven-MJAVADOC620-jar/pom.xml
@@ -1,0 +1,27 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
+  <artifactId>maven-MJAVADOC620-jar</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+</project>

--- a/src/it/projects/MJAVADOC-620_top-level-package/maven-MJAVADOC620-jar/src/main/java/Test.java
+++ b/src/it/projects/MJAVADOC-620_top-level-package/maven-MJAVADOC620-jar/src/main/java/Test.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Sample top-level class that is packaged into a non-module JAR.
+ */
+public class Test
+{
+}

--- a/src/it/projects/MJAVADOC-620_top-level-package/pom.xml
+++ b/src/it/projects/MJAVADOC-620_top-level-package/pom.xml
@@ -1,0 +1,52 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
+  <artifactId>maven-MJAVADOC-620-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Maven MJAVADOC-620 Test</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
+      <artifactId>maven-MJAVADOC620-jar</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>@project.version@</version>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/projects/MJAVADOC-620_top-level-package/src/main/java/TestUsage.java
+++ b/src/it/projects/MJAVADOC-620_top-level-package/src/main/java/TestUsage.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Sample class that tries to use top-level class from a non-module JAR.
+ */
+public class TestUsage
+{
+    /**
+     * Sample method that uses the top-level Test class from the other project.
+     */
+    public Test getTest()
+    {
+        return new Test();
+    }
+}

--- a/src/it/projects/MJAVADOC-620_top-level-package/verify.bsh
+++ b/src/it/projects/MJAVADOC-620_top-level-package/verify.bsh
@@ -1,0 +1,63 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+boolean result = true;
+
+try
+{
+    File target = new File( basedir, "target" );
+    if ( !target.exists() || !target.isDirectory() )
+    {
+        System.err.println( "target file is missing or not a directory." );
+        return false;
+    }
+
+    File apidocs = new File( basedir, "target/site/apidocs" );
+    if ( !apidocs.exists() || !apidocs.isDirectory() )
+    {
+        System.err.println( "target/site/apidocs file is missing or not a directory." );
+        return false;
+    }
+
+    File options = new File( apidocs, "options" );
+    if ( !options.exists() || !options.isFile() )
+    {
+        System.err.println( "target/site/apidocs/options file is missing or not a file." );
+        return false;
+    }
+
+    String str = FileUtils.fileRead( options );
+
+    if ( !str.contains( "maven-MJAVADOC620-jar-1.0-SNAPSHOT.jar" ) )
+    {
+        System.err.println( "Javadoc doesn't use correct artifacts." );
+        return false;
+    }
+}
+catch( IOException e )
+{
+    e.printStackTrace();
+    result = false;
+}
+
+return result;

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -5170,6 +5170,18 @@ public abstract class AbstractJavadocMojo
                     }
                 }
 
+                /* MJAVADOC-620: also add all JARs where module-name-guessing leads to a FindException: */
+                for ( Entry<File, Exception> pathExceptionEntry : result.getPathExceptions().entrySet() )
+                {
+                    Exception exception = pathExceptionEntry.getValue();
+                    // For Java < 9 compatibility, reference FindException by name:
+                    if ( "java.lang.module.FindException".equals( exception.getClass().getName() ) )
+                    {
+                        File jarPath = pathExceptionEntry.getKey();
+                        classPathElements.add( jarPath );
+                    }
+                }
+
                 String classpath = StringUtils.join( classPathElements.iterator(), File.pathSeparator );
                 addArgIfNotEmpty( arguments, "--class-path", JavadocUtil.quotedPathArgument( classpath ), false,
                                   false );


### PR DESCRIPTION
When `locationManager.resolvePaths()` processes JARs that do not define a module name, module-name-guessing is triggered. The last resort is to use the JAR's file name to derive a module name. The heuristic is to determine where a version number starts, for which the regex is used: `"-(\\d+(\\.|$))"`
See [JavaDoc of ModuleFinder.of()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/module/ModuleFinder.html#of(java.nio.file.Path...)).

For the remaining prefix, all non-alphanumeric characters (this includes dashes) are replaced by dots. When splitting at the dots, every part must be a legal Java identifier.

Now, when a Maven JAR uses the version `1-SNAPSHOT`, the JAR is named `<artifactId>-1-SNAPSHOT.jar`, so the version suffix is not recognized by the heuristic (the number is neither followed by a dot, nor is this the end of the file name without extension), so trying to guess the module name eventually fails with an error (FindException, "1" is not a valid Java identifier).

There are other situations in which trying to derive module information from a JAR leads to errors, e.g. when the top-level package is used ("unnamed package not allowed in module").

The code in `maven-javadoc-plugin` checks all returned `classpath` elements whether they contain module information. Now, in the result returned by `locationManager.resolvePaths()`, all JARs for that no module information could be derived are not contained in `getClasspathElements()`, but only in `getPathExceptions()`. When a JAR path is mapped to a `FindException`, it does not make sense to look for module information, but it _does_ make sense to still add these JARs to the classpath.
Ignoring them, as before, is what breaks backwards-compatibility with non-module JARs and causes bug [MJAVADOC-620](https://issues.apache.org/jira/projects/MJAVADOC/issues/MJAVADOC-620).

The fix is to add all such JARs without module information to the JavaDoc `classpath`.

**Filled-in Template:**

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJAVADOC) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes. --> **[MJAVADOC-620](https://issues.apache.org/jira/projects/MJAVADOC/issues/MJAVADOC-620)**
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
