### PR TITLE
MJAVADOC-661: Fix for tagletArtifact fails to scan multi-release JARs (MRJARs) for Taglets

### DIFF
--- a/src/it/projects/MJAVADOC-661_mrjar/invoker.properties
+++ b/src/it/projects/MJAVADOC-661_mrjar/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean install javadoc:javadoc
+invoker.java.version = 9+

--- a/src/it/projects/MJAVADOC-661_mrjar/pom.xml
+++ b/src/it/projects/MJAVADOC-661_mrjar/pom.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.javadoc.it</groupId>
+  <artifactId>mjavadoc661</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <url>https://issues.apache.org/jira/browse/MJAVADOC-661</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <profiles>
+    <profile>
+      <id>jdk10+</id>
+      <activation><jdk>[10,)</jdk></activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>jdk10</id>
+                  <goals>
+                    <goal>compile</goal>
+                  </goals>
+                  <configuration>
+                    <release>10</release>
+                    <compileSourceRoots>
+                      <compileSourceRoot>${project.basedir}/src/main/java10</compileSourceRoot>
+                    </compileSourceRoots>
+                    <multiReleaseOutput>true</multiReleaseOutput>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk11+</id>
+      <activation><jdk>[11,)</jdk></activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>jdk11</id>
+                  <goals>
+                    <goal>compile</goal>
+                  </goals>
+                  <configuration>
+                    <release>11</release>
+                    <compileSourceRoots>
+                      <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>
+                    </compileSourceRoots>
+                    <multiReleaseOutput>true</multiReleaseOutput>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk12+</id>
+      <activation><jdk>[12,)</jdk></activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>jdk12</id>
+                  <goals>
+                    <goal>compile</goal>
+                  </goals>
+                  <configuration>
+                    <release>12</release>
+                    <compileSourceRoots>
+                      <compileSourceRoot>${project.basedir}/src/main/java12</compileSourceRoot>
+                    </compileSourceRoots>
+                    <multiReleaseOutput>true</multiReleaseOutput>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk13+</id>
+      <activation><jdk>[13,)</jdk></activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>jdk13</id>
+                  <goals>
+                    <goal>compile</goal>
+                  </goals>
+                  <configuration>
+                    <release>13</release>
+                    <compileSourceRoots>
+                      <compileSourceRoot>${project.basedir}/src/main/java13</compileSourceRoot>
+                    </compileSourceRoots>
+                    <multiReleaseOutput>true</multiReleaseOutput>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+          <executions>
+            <execution>
+              <id>default-compile</id>
+              <configuration>
+                <release>9</release>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <manifestEntries>
+                  <Multi-Release>true</Multi-Release>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <tagletArtifacts>
+            <tagletArtifact>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>${project.artifactId}</artifactId>
+              <version>${project.version}</version>
+            </tagletArtifact>
+          </tagletArtifacts>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/projects/MJAVADOC-661_mrjar/src/main/java/com/foo/AbstractTaglet.java
+++ b/src/it/projects/MJAVADOC-661_mrjar/src/main/java/com/foo/AbstractTaglet.java
@@ -1,0 +1,55 @@
+package com.foo;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.sun.source.doctree.DocTree;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import javax.lang.model.element.Element;
+import jdk.javadoc.doclet.Taglet;
+
+public abstract class AbstractTaglet implements Taglet
+{
+    @Override
+    public String getName( )
+    {
+        return getClass( ).getSimpleName( );
+    }
+
+    @Override
+    public boolean isInlineTag( )
+    {
+        return true;
+    }
+
+
+    @Override
+    public Set<Taglet.Location> getAllowedLocations()
+    {
+        return EnumSet.allOf(Taglet.Location.class);
+    }
+
+    @Override
+    public String toString( List<? extends DocTree> tags, Element element )
+    {
+        return getName( );
+    }
+}

--- a/src/it/projects/MJAVADOC-661_mrjar/src/main/java/com/foo/Taglet9.java
+++ b/src/it/projects/MJAVADOC-661_mrjar/src/main/java/com/foo/Taglet9.java
@@ -1,0 +1,24 @@
+package com.foo;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Taglet9 extends AbstractTaglet
+{
+}

--- a/src/it/projects/MJAVADOC-661_mrjar/src/main/java10/com/foo/Taglet10.java
+++ b/src/it/projects/MJAVADOC-661_mrjar/src/main/java10/com/foo/Taglet10.java
@@ -1,0 +1,24 @@
+package com.foo;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Taglet10 extends AbstractTaglet
+{
+}

--- a/src/it/projects/MJAVADOC-661_mrjar/src/main/java11/com/foo/Taglet11.java
+++ b/src/it/projects/MJAVADOC-661_mrjar/src/main/java11/com/foo/Taglet11.java
@@ -1,0 +1,24 @@
+package com.foo;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Taglet11 extends AbstractTaglet
+{
+}

--- a/src/it/projects/MJAVADOC-661_mrjar/src/main/java12/com/foo/Taglet12.java
+++ b/src/it/projects/MJAVADOC-661_mrjar/src/main/java12/com/foo/Taglet12.java
@@ -1,0 +1,24 @@
+package com.foo;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Taglet12 extends AbstractTaglet
+{
+}

--- a/src/it/projects/MJAVADOC-661_mrjar/src/main/java13/com/foo/Taglet13.java
+++ b/src/it/projects/MJAVADOC-661_mrjar/src/main/java13/com/foo/Taglet13.java
@@ -1,0 +1,24 @@
+package com.foo;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Taglet13 extends AbstractTaglet
+{
+}

--- a/src/it/projects/MJAVADOC-661_mrjar/verify.groovy
+++ b/src/it/projects/MJAVADOC-661_mrjar/verify.groovy
@@ -18,12 +18,12 @@
  */
 
 int javaVersion = System.getProperty( "java.specification.version" ) as Integer
-def versions = 9..javaVersion
+def versions = 9..Math.min( 13, javaVersion )
 def required = []
 
 versions.each { required << "'com.foo.Taglet" + it + "'" }
 
-def options = new File( basedir, 'target/site/apidocs/options');
+def options = new File( basedir, 'target/site/apidocs/options' );
 
 assert options.exists() : options + " not found"
 

--- a/src/it/projects/MJAVADOC-661_mrjar/verify.groovy
+++ b/src/it/projects/MJAVADOC-661_mrjar/verify.groovy
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+int javaVersion = System.getProperty( "java.specification.version" ) as Integer
+def versions = 9..javaVersion
+def required = []
+
+versions.each { required << "'com.foo.Taglet" + it + "'" }
+
+def options = new File( basedir, 'target/site/apidocs/options');
+
+assert options.exists() : options + " not found"
+
+def lines = options.readLines( )
+def found = lines.findAll { it.matches( "'com.foo.Taglet[0-9]+'" ) }
+
+required.removeAll( found )
+
+assert required.size( ) == 0 : required + " not found"

--- a/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
@@ -49,7 +49,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.Set;
@@ -1017,16 +1016,23 @@ public class JavadocUtil
         }
 
         List<String> classes = new ArrayList<>();
+        Pattern pattern =
+            Pattern.compile( "(?i)^(META-INF/versions/(?<v>[0-9]+)/)?(?<n>.+)[.]class$" );
         try ( JarInputStream jarStream = new JarInputStream( new FileInputStream( jarFile ) ) )
         {
             for ( JarEntry jarEntry = jarStream.getNextJarEntry(); jarEntry != null; jarEntry =
                 jarStream.getNextJarEntry() )
             {
-                if ( jarEntry.getName().toLowerCase( Locale.ENGLISH ).endsWith( ".class" ) )
+                Matcher matcher = pattern.matcher( jarEntry.getName() );
+                if ( matcher.matches() )
                 {
-                    String name = jarEntry.getName().substring( 0, jarEntry.getName().indexOf( "." ) );
+                    String version = matcher.group( "v" );
+                    if ( StringUtils.isEmpty( version ) || JavaVersion.JAVA_VERSION.isAtLeast( version ) )
+                    {
+                        String name = matcher.group( "n" );
 
-                    classes.add( name.replaceAll( "/", "\\." ) );
+                        classes.add( name.replaceAll( "/", "\\." ) );
+                    }
                 }
 
                 jarStream.closeEntry();


### PR DESCRIPTION
JavadocUtil.getClassNamesFromJar(File) translates JarEntry names to Class names by first testing if the entry ends in ".class" and then translating the whole JarEntry name simply by replacing "/" with ".".  This fails for classes in multi-release JARs under the META-INF/versions/** hierarchy.

This change filters "*.class" files from the META-INF/versions/** hierarchy testing against JavaVersion.JAVA_VERSION.isAtLeast(String).

I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)


