### PR TITLE
[MJAVADOC-664] - Fix stale javadoc data detection on Windows.

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/StaleHelper.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/StaleHelper.java
@@ -57,7 +57,7 @@ public class StaleHelper
             List<String> ignored = new ArrayList<>();
             List<String> options = new ArrayList<>();
             Path dir = cmd.getWorkingDirectory().toPath().toAbsolutePath().normalize();
-            String[] args = cmd.getCommandline();
+            String[] args = cmd.getArguments();
             Collections.addAll( options, args );
             for ( String arg : args )
             {


### PR DESCRIPTION
Replaces the usage of the full commandline by only its arguments to generate the stale javadoc detection key.
This approach allows to handle file-arguments appropriately in case of double-quoting by resolving them to their actual arguments.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)


