### PR TITLE
[MJAVADOC-697] Allowing to register alternative Javadoc implementation

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -293,6 +293,9 @@ public abstract class AbstractJavadocMojo
     @Component
     private DependencyResolver dependencyResolver;
 
+    @Component
+    private List<JavadocImplementation> javadocInvocators;
+
     /**
      * Project builder
      *
@@ -5721,7 +5724,16 @@ public abstract class AbstractJavadocMojo
         CommandLineUtils.StringStreamConsumer out = new JavadocUtil.JavadocOutputStreamConsumer();
         try
         {
-            int exitCode = CommandLineUtils.executeCommandLine( cmd, out, err );
+            getLog().debug( "javadocInvocators: " + javadocInvocators );
+            int exitCode;
+            if ( javadocInvocators.isEmpty() )
+            {
+                exitCode = CommandLineUtils.executeCommandLine( cmd, out, err );
+            }
+            else
+            {
+                exitCode = javadocInvocators.get( 0 ).execute( cmd, out, err );
+            }
 
             String output = ( StringUtils.isEmpty( out.getOutput() ) ? null : '\n' + out.getOutput().trim() );
 

--- a/src/main/java/org/apache/maven/plugins/javadoc/JavadocImplementation.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/JavadocImplementation.java
@@ -1,0 +1,39 @@
+package org.apache.maven.plugins.javadoc;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.codehaus.plexus.util.cli.CommandLineException;
+import org.codehaus.plexus.util.cli.CommandLineUtils;
+
+/**
+ * Alternative way to invoke Javadoc. By default the system uses
+ * {@link CommandLineUtils#executeCommandLine}
+ * to invoke the {@code javadoc} command. By registering a different
+ * implementation of {@code JavadocImplementation}, one can change the way
+ * the {@code javadoc} tool is invoked.
+ */
+public interface JavadocImplementation
+{
+  int execute(
+        org.codehaus.plexus.util.cli.Commandline cmd, 
+        org.codehaus.plexus.util.cli.CommandLineUtils.StringStreamConsumer out, 
+        org.codehaus.plexus.util.cli.CommandLineUtils.StringStreamConsumer err
+  ) throws CommandLineException;
+}


### PR DESCRIPTION
The Maven compiler plugin allows different implementations of compilers to plug in. One of the very useful ones is the [retrofit compiler for Java](http://frgaal.org) that allows one to use syntax of JDK-16 while running on old JDKs.

The compiler works fine, however the problem comes when one wants to generate Javadoc. Because the source code is using newer language constructs, classical javadoc from old JDKs fails. One either has to generate the Javadoc on a newest JDK (which beats the purpose of retrofit compiler) or give up on Javadoc. Or...

Let's enhance the Maven Javadoc Plugin to support alternative implementations of Javadoc, just like the Maven Compiler Plugin does with compilers!

 - [ x ] Addressing [MJAVADOC-697](https://issues.apache.org/jira/browse/MJAVADOC-697)
 - [ x ] Each commit in the pull request should have a meaningful subject line and body.
 - [ x ] Format the pull request title like `[MJAVADOC-XXX]` 
 - [ x ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ x ] Run `mvn clean verify -Prun-its` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

Pull request is about ~20 lines of code - no need to sign an [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf). To make clear that you license your contribution under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) you have to acknowledge this by using the following check-box.

 - [ x ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

