### PR TITLE
(doc) Update plugin' configuration parameter (MJAVADOC-475)

### DIFF
--- a/src/it/projects/examples/alternate-doclet/pom.xml
+++ b/src/it/projects/examples/alternate-doclet/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>umlgraph</artifactId>
             <version>5.6.6</version>
           </docletArtifact>
-          <additionalparam>-views</additionalparam>
+          <additionalOptions>-views</additionalOptions>
         </configuration>
       </plugin>
       <!-- END SNIPPET: umlgraph -->


### PR DESCRIPTION
[MJAVADOC-475](https://issues.apache.org/jira/browse/MJAVADOC-475?focusedCommentId=16516951&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16516951):

> The documentation still uses the old additionalparams: https://maven.apache.org/plugins/maven-javadoc-plugin/examples/alternate-doclet.html
>
> This is not supposed to work anymore, or is it?
