### PR TITLE
(doc) Update plugin' configuration parameter (MJAVADOC-475)

### DIFF
--- a/src/it/projects/examples/alternate-doclet/pom.xml
+++ b/src/it/projects/examples/alternate-doclet/pom.xml
@@ -47,7 +47,9 @@
             <artifactId>umlgraph</artifactId>
             <version>5.6.6</version>
           </docletArtifact>
-          <additionalOptions>-views</additionalOptions>
+          <additionalOptions>
+            <option>-views</option>
+          </additionalOptions>
         </configuration>
       </plugin>
       <!-- END SNIPPET: umlgraph -->


### PR DESCRIPTION
@slachiewicz - thanks for checking
- #123

Seems that maven 3.2.5, that https://ci-maven.apache.org/job/Maven/job/maven-box/job/maven-javadoc-plugin/job/master/5/execution/node/195/log/ failed with, is old enough to not support one-element lists in configuration, as newer do.