### PR TITLE
[MJAVADOC-652] - Dependencies on the patch-module path

### DIFF
--- a/src/it/projects/MJAVADOC-652/invoker.properties
+++ b/src/it/projects/MJAVADOC-652/invoker.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.java.version = 9+
+invoker.goals.1=clean package
+invoker.buildResult.1 = success
+
+invoker.goals.2=clean package -DdisableModulePath=true
+invoker.buildResult.2 = success

--- a/src/it/projects/MJAVADOC-652/pom.xml
+++ b/src/it/projects/MJAVADOC-652/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ Licensed to the Apache Software Foundation (ASF) under one ~ or more contributor license agreements. See the NOTICE 
+    file ~ distributed with this work for additional information ~ regarding copyright ownership. The ASF licenses this file 
+    ~ to you under the Apache License, Version 2.0 (the ~ "License"); you may not use this file except in compliance ~ with the 
+    License. You may obtain a copy of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 ~ ~ Unless required by applicable 
+    law or agreed to in writing, ~ software distributed under the License is distributed on an ~ "AS IS" BASIS, WITHOUT WARRANTIES 
+    OR CONDITIONS OF ANY ~ KIND, either express or implied. See the License for the ~ specific language governing permissions 
+    and limitations ~ under the License. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.maven.plugins.javadoc.its</groupId>
+    <artifactId>MJAVADOC-652</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${project.groupId}.test</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.4.0</version>
+                <executions>
+                    <execution>
+                        <id>default-attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/projects/MJAVADOC-652/src/main/java/org/apache/maven/it/NoopFilter.java
+++ b/src/it/projects/MJAVADOC-652/src/main/java/org/apache/maven/it/NoopFilter.java
@@ -1,0 +1,53 @@
+package org.apache.maven.it;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+
+/**
+ * Do nothing on any method. Implements {@link Filter}.
+ */
+@WebFilter( "/block" )
+public class NoopFilter implements Filter
+{
+    
+    @Override
+    public void init( final FilterConfig filterConfig )
+    {
+        // noop
+    }
+
+    @Override
+    public void doFilter( final ServletRequest request, final ServletResponse response, final FilterChain chain )
+    {
+        // noop
+    }
+    
+    @Override
+    public void destroy()
+    {
+        // noop
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -1828,6 +1828,15 @@ public abstract class AbstractJavadocMojo
     @Parameter( defaultValue = "${project.build.outputTimestamp}" )
     protected String outputTimestamp;
 
+    /**
+     * Forcibly disable support for using Java 9 module paths when building Javadoc
+     * options. Default is false i.e. allow module paths if running in a suitable environment.
+     *
+     * @since 3.4.1
+     */
+    @Parameter( property = "disableModulePath", defaultValue = "false" )
+    private boolean disableSupportForModulePath;
+
     // ----------------------------------------------------------------------
     // protected methods
     // ----------------------------------------------------------------------
@@ -5158,14 +5167,21 @@ public abstract class AbstractJavadocMojo
 
         Map<String, JavaModuleDescriptor> allModuleDescriptors = new HashMap<>();
 
-        boolean supportModulePath = javadocRuntimeVersion.isAtLeast( "9" );
-        if ( release != null )
-        {
-            supportModulePath &= JavaVersion.parse( release ).isAtLeast( "9" );
-        }
-        else if ( source != null )
-        {
-            supportModulePath &= JavaVersion.parse( source ).isAtLeast( "9" );
+        boolean supportModulePath = false;
+
+        if ( !disableSupportForModulePath )
+            {
+
+            supportModulePath = javadocRuntimeVersion.isAtLeast( "9" );
+
+            if ( release != null )
+            {
+                supportModulePath &= JavaVersion.parse( release ).isAtLeast( "9" );
+            }
+            else if ( source != null )
+            {
+                supportModulePath &= JavaVersion.parse( source ).isAtLeast( "9" );
+            }
         }
 
         if ( supportModulePath )


### PR DESCRIPTION
Add parameter to turn off support for the module path even if supported by the environment.

To bypass module-path and patch-module-path arguments from being created for Javadoc even if using Java 9 and your project declares support for modules e.g. includes an automatic module name.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] https://issues.apache.org/jira/browse/MJAVADOC-652
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify -Prun-its` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

