### PR TITLE
Log javadoc warnings and errors to file

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -183,27 +183,33 @@ public abstract class AbstractJavadocMojo
 
     /**
      * The <code>options</code> file name in the output directory when calling:
-     * <code>javadoc.exe(or .sh) &#x40;options &#x40;packages | &#x40;argfile | &#x40;files</code>
+     * <code>javadoc.exe(or .sh) &#x40;options &#x40;packages | &#x40;argfile | &#x40;files | &#x40;errors</code>
      */
     protected static final String OPTIONS_FILE_NAME = "options";
 
     /**
      * The <code>packages</code> file name in the output directory when calling:
-     * <code>javadoc.exe(or .sh) &#x40;options &#x40;packages | &#x40;argfile | &#x40;files</code>
+     * <code>javadoc.exe(or .sh) &#x40;options &#x40;packages | &#x40;argfile | &#x40;files | &#x40;errors</code>
      */
     protected static final String PACKAGES_FILE_NAME = "packages";
 
     /**
      * The <code>argfile</code> file name in the output directory when calling:
-     * <code>javadoc.exe(or .sh) &#x40;options &#x40;packages | &#x40;argfile | &#x40;files</code>
+     * <code>javadoc.exe(or .sh) &#x40;options &#x40;packages | &#x40;argfile | &#x40;files | &#x40;errors</code>
      */
     protected static final String ARGFILE_FILE_NAME = "argfile";
 
     /**
      * The <code>files</code> file name in the output directory when calling:
-     * <code>javadoc.exe(or .sh) &#x40;options &#x40;packages | &#x40;argfile | &#x40;files</code>
+     * <code>javadoc.exe(or .sh) &#x40;options &#x40;packages | &#x40;argfile | &#x40;files | &#x40;errors</code>
      */
     protected static final String FILES_FILE_NAME = "files";
+
+    /**
+     * The <code>errors</code> file name in the output directory when calling:
+     * <code>javadoc.exe(or .sh) &#x40;options &#x40;packages | &#x40;argfile | &#x40;files | &#x40;errors</code>
+     */
+    protected static final String ERRORS_FILE_NAME = "errors";
 
     /**
      * The current class directory
@@ -6077,6 +6083,11 @@ public abstract class AbstractJavadocMojo
                     getLog().info( output );
                 }
 
+                if ( StringUtils.isNotEmpty( err.getOutput() ) )
+                {
+                    writeErrorFile( err.getOutput(), javadocOutputDirectory );
+                }
+
                 StringBuilder msg = new StringBuilder( "\nExit code: " );
                 msg.append( exitCode );
                 if ( StringUtils.isNotEmpty( err.getOutput() ) )
@@ -6876,6 +6887,33 @@ public abstract class AbstractJavadocMojo
         catch ( IOException e )
         {
             logError( "Unable to write '" + commandLineFile.getName() + "' debug script file", e );
+        }
+    }
+
+    /**
+     * Write a files containing the javadoc errors and warnings.
+     *
+     * @param errorsAndWarnings      the javadoc errors and warnings as string, not null.
+     * @param javadocOutputDirectory the output dir, not null.
+     * @since 3.4.1-SNAPSHOT
+     */
+    private void writeErrorFile( String errorsAndWarnings, File javadocOutputDirectory )
+    {
+        File commandLineFile = new File( javadocOutputDirectory, ERRORS_FILE_NAME );
+        commandLineFile.getParentFile().mkdirs();
+
+        try
+        {
+            FileUtils.fileWrite( commandLineFile.getAbsolutePath(), null /* platform encoding */, errorsAndWarnings );
+
+            if ( !SystemUtils.IS_OS_WINDOWS )
+            {
+                Runtime.getRuntime().exec( new String[]{ "chmod", "a+x", commandLineFile.getAbsolutePath() } );
+            }
+        }
+        catch ( IOException e )
+        {
+            logError( "Unable to write '" + commandLineFile.getName() + "' errors file", e );
         }
     }
 

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -6895,7 +6895,7 @@ public abstract class AbstractJavadocMojo
      *
      * @param errorsAndWarnings      the javadoc errors and warnings as string, not null.
      * @param javadocOutputDirectory the output dir, not null.
-     * @since 3.4.1-SNAPSHOT
+     * @since 3.4.2-SNAPSHOT
      */
     private void writeErrorFile( String errorsAndWarnings, File javadocOutputDirectory )
     {

--- a/src/main/java/org/apache/maven/plugins/javadoc/JavadocJar.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/JavadocJar.java
@@ -66,10 +66,11 @@ public class JavadocJar
      * @see AbstractJavadocMojo#PACKAGES_FILE_NAME
      * @see AbstractJavadocMojo#ARGFILE_FILE_NAME
      * @see AbstractJavadocMojo#FILES_FILE_NAME
+     * @see AbstractJavadocMojo#ERRORS_FILE_NAME
      */
     private static final String[] DEFAULT_EXCLUDES =
         new String[]{ DEBUG_JAVADOC_SCRIPT_NAME, OPTIONS_FILE_NAME, PACKAGES_FILE_NAME, ARGFILE_FILE_NAME,
-            FILES_FILE_NAME };
+            FILES_FILE_NAME, ERRORS_FILE_NAME };
 
     // ----------------------------------------------------------------------
     // Mojo components

--- a/src/test/java/org/apache/maven/plugins/javadoc/JavadocJarTest.java
+++ b/src/test/java/org/apache/maven/plugins/javadoc/JavadocJarTest.java
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JavadocJarTest
     extends AbstractMojoTestCase
 {
-    
+
     private JavadocJar lookupMojo( File testPom )
                     throws Exception
     {
@@ -51,13 +51,13 @@ public class JavadocJarTest
         MojoExecution mojoExec = new MojoExecution( new Plugin(), "javadoc", null );
 
         setVariableValueToObject( mojo, "mojo", mojoExec );
-        
+
         MavenProject currentProject = new MavenProjectStub();
         currentProject.setGroupId( "GROUPID" );
         currentProject.setArtifactId( "ARTIFACTID" );
-        
+
         setVariableValueToObject( mojo, "session", newMavenSession( currentProject ) );
-        
+
         return mojo;
     }
 
@@ -126,6 +126,7 @@ public class JavadocJarTest
         assertFalse( set.contains( AbstractJavadocMojo.FILES_FILE_NAME ) );
         assertFalse( set.contains( AbstractJavadocMojo.OPTIONS_FILE_NAME ) );
         assertFalse( set.contains( AbstractJavadocMojo.PACKAGES_FILE_NAME ) );
+        assertFalse( set.contains( AbstractJavadocMojo.ERRORS_FILE_NAME ) );
 
         //check if the javadoc files were created
         generatedFile =


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJAVADOC) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify -Prun-its` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Adds a new `@errors` file to the output directory, similar to the `@options`, `@packages`, `@argfile`, and `@files`, that contains the warnings and errors returned by the Javadoc process and won't be contained in a Javadoc JAR. This allows for external processes to capture warnings and errors produced during Javadoc generation without the need for complex logging processes and ensures that the Javadoc warnings and errors aren't interleaved with other data if the logger is handling requests from multiple threads.