### PR TITLE
[MJAVADOC-738] Upgrade commons-text to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@ under the License.
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.9</version>
+      <version>1.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Dependency upgrade to common-text 1.10.0

---

https://issues.apache.org/jira/browse/MJAVADOC-738
