### PR TITLE
[MJAVADOC-700] - Fixes duplicates classes in Java 8 all-classes lists on Windows

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -4550,7 +4550,7 @@ public abstract class AbstractJavadocMojo
                     continue;
                 }
 
-                if ( currentFile.indexOf( File.separatorChar ) == -1 )
+                if ( currentFile.indexOf( '/' ) == -1 )
                 {
                     returnList.add( currentSourcePath.resolve( currentFile ).toAbsolutePath().toString() );
                 }

--- a/src/test/java/org/apache/maven/plugins/javadoc/JavadocReportTest.java
+++ b/src/test/java/org/apache/maven/plugins/javadoc/JavadocReportTest.java
@@ -306,8 +306,12 @@ public class JavadocReportTest
         if ( JavaVersion.JAVA_SPECIFICATION_VERSION.isBefore( "11" ) )
         {
             assertThat( apidocs.resolve( "def/configuration/package-frame.html" )).exists();
-            assertThat( apidocs.resolve( "allclasses-frame.html" )).exists();
-            assertThat( apidocs.resolve( "allclasses-noframe.html" )).exists();
+            assertThat( apidocs.resolve( "allclasses-frame.html" )).exists()
+                                                                   .content().containsOnlyOnce("def/configuration/App.html")
+                                                                             .containsOnlyOnce("def/configuration/AppSample.html");
+            assertThat( apidocs.resolve( "allclasses-noframe.html" )).exists()
+                                                                     .content().containsOnlyOnce("def/configuration/App.html")
+                                                                               .containsOnlyOnce("def/configuration/AppSample.html");
         }
 
         // class level generated javadoc files


### PR DESCRIPTION
 Replaced an occurrence of File.separatorChar that causes classes to be listed twice in Java 8 on Windows.