### PR TITLE
[MNG-6825] Replace org.apache.maven.shared.utils.StringUtils

### DIFF
--- a/src/test/java/org/apache/maven/plugins/javadoc/JavadocReportTest.java
+++ b/src/test/java/org/apache/maven/plugins/javadoc/JavadocReportTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.LegacySupport;
@@ -43,7 +44,6 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Settings;
-import org.apache.maven.shared.utils.StringUtils;
 import org.apache.maven.shared.utils.io.FileUtils;
 import org.codehaus.plexus.languages.java.version.JavaVersion;
 import org.eclipse.aether.DefaultRepositorySystemSession;


### PR DESCRIPTION
So from https://issues.apache.org/jira/browse/MNG-6825 it seems the goal is to reduce the dependency on `org.apache.maven.shared.utils.StringUtils`, and replace that with `org.apache.commons.lang3.StringUtils` when also a dependency. (Unless I misunderstood). This is a first step towards that, after which only `io.FileUtils` is holding up dropping `maven-shared-utils`.