### PR TITLE
[MJAVADOC-743] Drop deprecated mojo parameter

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractFixJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractFixJavadocMojo.java
@@ -69,7 +69,6 @@ import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
-import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -349,12 +348,6 @@ public abstract class AbstractFixJavadocMojo extends AbstractMojo {
      */
     @Parameter(property = "level", defaultValue = "protected")
     private String level;
-
-    /**
-     * The local repository where the artifacts are located, used by the tests.
-     */
-    @Parameter(property = "localRepository")
-    private ArtifactRepository localRepository;
 
     /**
      * Output directory where Java classes will be rewritten.
@@ -657,7 +650,7 @@ public abstract class AbstractFixJavadocMojo extends AbstractMojo {
 
         JavadocUtil.invokeMaven(
                 getLog(),
-                new File(localRepository.getBasedir()),
+                session.getRepositorySession().getLocalRepository().getBasedir(),
                 project.getFile(),
                 Collections.singletonList(clirrGoal),
                 properties,

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -63,7 +63,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
-import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.execution.MavenSession;
@@ -415,12 +414,6 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
      */
     @Parameter(property = "resourcesArtifacts")
     private ResourcesArtifact[] resourcesArtifacts;
-
-    /**
-     * The local repository where the artifacts are located.
-     */
-    @Parameter(property = "localRepository")
-    private ArtifactRepository localRepository;
 
     /**
      * The projects in the reactor for aggregation report.
@@ -5476,7 +5469,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
                 try {
                     JavadocUtil.invokeMaven(
                             getLog(),
-                            new File(localRepository.getBasedir()),
+                            session.getRepositorySession().getLocalRepository().getBasedir(),
                             p.getFile(),
                             Collections.singletonList(javadocGoal),
                             null,

--- a/src/test/java/org/apache/maven/plugins/javadoc/FixJavadocMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/javadoc/FixJavadocMojoTest.java
@@ -39,6 +39,9 @@ import org.apache.maven.plugins.javadoc.AbstractFixJavadocMojo.JavaEntityTags;
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
+import org.eclipse.aether.repository.LocalRepository;
 
 import static org.apache.commons.lang3.reflect.MethodUtils.invokeMethod;
 
@@ -496,6 +499,10 @@ public class FixJavadocMojoTest extends AbstractMojoTestCase {
         assertNotNull(mojo);
 
         MavenSession session = newMavenSession(mojo.getProject());
+        ((DefaultRepositorySystemSession) session.getRepositorySession())
+                .setLocalRepositoryManager(new SimpleLocalRepositoryManagerFactory()
+                        .newInstance(
+                                session.getRepositorySession(), new LocalRepository(new File("target/local-repo"))));
         // Ensure remote repo connection uses SSL
         File globalSettingsFile = new File(getBasedir(), "target/test-classes/unit/settings.xml");
         session.getRequest().setGlobalSettingsFile(globalSettingsFile);

--- a/src/test/java/org/apache/maven/plugins/javadoc/JavadocJarTest.java
+++ b/src/test/java/org/apache/maven/plugins/javadoc/JavadocJarTest.java
@@ -25,12 +25,16 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.languages.java.version.JavaVersion;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
+import org.eclipse.aether.repository.LocalRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,7 +54,12 @@ public class JavadocJarTest extends AbstractMojoTestCase {
         currentProject.setGroupId("GROUPID");
         currentProject.setArtifactId("ARTIFACTID");
 
-        setVariableValueToObject(mojo, "session", newMavenSession(currentProject));
+        MavenSession session = newMavenSession(currentProject);
+        ((DefaultRepositorySystemSession) session.getRepositorySession())
+                .setLocalRepositoryManager(new SimpleLocalRepositoryManagerFactory()
+                        .newInstance(
+                                session.getRepositorySession(), new LocalRepository(new File("target/local-repo"))));
+        setVariableValueToObject(mojo, "session", session);
 
         return mojo;
     }

--- a/src/test/resources/unit/aggregate-modules-not-in-subfolders-test/all/pom.xml
+++ b/src/test/resources/unit/aggregate-modules-not-in-subfolders-test/all/pom.xml
@@ -37,7 +37,6 @@ under the License.
         <configuration>
           <encoding>ISO-8859-1</encoding>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.AggregateNotInSubFolderTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/aggregate-modules-not-in-subfolders-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/aggregate-modules-not-in-subfolders-test/target/javadoc-bundle-options</javadocOptionsDir>
           <windowtitle>Maven Javadoc Plugin aggregate resources 1.0-SNAPSHOT API</windowtitle>

--- a/src/test/resources/unit/aggregate-resources-test/aggregate-resources-test-plugin-config.xml
+++ b/src/test/resources/unit/aggregate-resources-test/aggregate-resources-test-plugin-config.xml
@@ -35,7 +35,6 @@ under the License.
         <configuration>
           <encoding>ISO-8859-1</encoding>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.AggregateResourcesTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/aggregate-resources-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/aggregate-resources-test/target/javadoc-bundle-options</javadocOptionsDir>
           <windowtitle>Maven Javadoc Plugin aggregate resources 1.0-SNAPSHOT API</windowtitle>

--- a/src/test/resources/unit/aggregate-test/aggregate-test-plugin-config.xml
+++ b/src/test/resources/unit/aggregate-test/aggregate-test-plugin-config.xml
@@ -35,7 +35,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.AggregateTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/aggregate-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/aggregate-test/target/javadoc-bundle-options</javadocOptionsDir>
           <breakiterator>false</breakiterator>

--- a/src/test/resources/unit/custom-configuration/custom-configuration-plugin-config.xml
+++ b/src/test/resources/unit/custom-configuration/custom-configuration-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.CustomConfigurationMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/custom-configuration/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/custom-configuration/target/javadoc-bundle-options</javadocOptionsDir>
           <breakiterator>false</breakiterator>

--- a/src/test/resources/unit/default-configuration/default-configuration-plugin-config.xml
+++ b/src/test/resources/unit/default-configuration/default-configuration-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.DefaultConfigurationMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/default-configuration/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/default-configuration/target/javadoc-bundle-options</javadocOptionsDir>
           <breakiterator>false</breakiterator>

--- a/src/test/resources/unit/docfiles-test/docfiles-test-plugin-config.xml
+++ b/src/test/resources/unit/docfiles-test/docfiles-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.DocfilesTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/docfiles-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/docfiles-test/target/javadoc-bundle-options</javadocOptionsDir>
           <breakiterator>false</breakiterator>

--- a/src/test/resources/unit/docfiles-with-java-test/docfiles-with-java-test-plugin-config.xml
+++ b/src/test/resources/unit/docfiles-with-java-test/docfiles-with-java-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.DocfilesWithJavaTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/docfiles-with-java-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/docfiles-with-java-test/target/javadoc-bundle-options</javadocOptionsDir>
           <javadocDirectory>${basedir}/src/test/resources/unit/docfiles-with-java-test/src/main</javadocDirectory>

--- a/src/test/resources/unit/doclet-path-test/doclet-path-test-plugin-config.xml
+++ b/src/test/resources/unit/doclet-path-test/doclet-path-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.DocletPathTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/doclet-path-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/doclet-path-test/target/javadoc-bundle-options</javadocOptionsDir>
           <doclet>UmlGraph</doclet>

--- a/src/test/resources/unit/doclet-test/doclet-test-plugin-config.xml
+++ b/src/test/resources/unit/doclet-test/doclet-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.DocletTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/doclet-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/doclet-test/target/javadoc-bundle-options</javadocOptionsDir>
           <doclet>UmlGraph</doclet>

--- a/src/test/resources/unit/file-include-exclude-test/file-include-exclude-plugin-config.xml
+++ b/src/test/resources/unit/file-include-exclude-test/file-include-exclude-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.SubpackagesTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/file-include-exclude-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/file-include-exclude-test/target/javadoc-bundle-options</javadocOptionsDir>
           <breakiterator>false</breakiterator>

--- a/src/test/resources/unit/fix-test/pom.xml
+++ b/src/test/resources/unit/fix-test/pom.xml
@@ -43,7 +43,6 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.FixMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/fix-test/target/generated</outputDirectory>
           <defaultSince>1.1-SNAPSHOT</defaultSince>
           <encoding>UTF-8</encoding>

--- a/src/test/resources/unit/header-footer-test/header-footer-test-plugin-config.xml
+++ b/src/test/resources/unit/header-footer-test/header-footer-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.HeaderFooterTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/header-footer-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/header-footer-test/target/javadoc-bundle-options</javadocOptionsDir>
           <show>protected</show>

--- a/src/test/resources/unit/helpfile-test/artifact-helpfile/org/apache/maven/plugins/maven-javadoc-plugin/unit/helpfile-test/1.0-SNAPSHOT/helpfile-test-1.0-SNAPSHOT.pom
+++ b/src/test/resources/unit/helpfile-test/artifact-helpfile/org/apache/maven/plugins/maven-javadoc-plugin/unit/helpfile-test/1.0-SNAPSHOT/helpfile-test-1.0-SNAPSHOT.pom
@@ -35,7 +35,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.HelpFileMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/helpfile-test/target/site/apidocs</outputDirectory>
           <javadocDirectory>${basedir}/src/test/resources/unit/helpfile-test/src/main/javadoc</javadocDirectory>
           <breakiterator>false</breakiterator>

--- a/src/test/resources/unit/helpfile-test/pom.xml
+++ b/src/test/resources/unit/helpfile-test/pom.xml
@@ -35,7 +35,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.HelpFileMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/helpfile-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/helpfile-test/target/javadoc-bundle-options</javadocOptionsDir>
           <javadocDirectory>${basedir}/src/test/resources/unit/helpfile-test/src/main/javadoc</javadocDirectory>

--- a/src/test/resources/unit/javaHome-test/javaHome-test-plugin-config.xml
+++ b/src/test/resources/unit/javaHome-test/javaHome-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.DefaultConfigurationMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/javaHome-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/javaHome-test/target/javadoc-bundle-options</javadocOptionsDir>
           <breakiterator>false</breakiterator>

--- a/src/test/resources/unit/javadocjar-archive-config/javadocjar-archive-config.xml
+++ b/src/test/resources/unit/javadocjar-archive-config/javadocjar-archive-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.JavadocJarArchiveConfigProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <jarOutputDirectory>${basedir}/target/test/unit/javadocjar-archive-config/target</jarOutputDirectory>
           <outputDirectory>${basedir}/target/test/unit/javadocjar-archive-config/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/javadocjar-archive-config/target/javadoc-bundle-options</javadocOptionsDir>

--- a/src/test/resources/unit/javadocjar-default/javadocjar-default-plugin-config.xml
+++ b/src/test/resources/unit/javadocjar-default/javadocjar-default-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.JavadocJarDefaultMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <jarOutputDirectory>${basedir}/target/test/unit/javadocjar-default/target</jarOutputDirectory>
           <outputDirectory>${basedir}/target/test/unit/javadocjar-default/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/javadocjar-default/target/javadoc-bundle-options</javadocOptionsDir>

--- a/src/test/resources/unit/javadocjar-failonerror/javadocjar-failonerror-plugin-config.xml
+++ b/src/test/resources/unit/javadocjar-failonerror/javadocjar-failonerror-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.JavadocJarFailOnErrorMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <jarOutputDirectory>${basedir}/target/test/unit/javadocjar-failonerror/target</jarOutputDirectory>
           <outputDirectory>${basedir}/target/test/unit/javadocjar-failonerror/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/javadocjar-failonerror/target/javadoc-bundle-options</javadocOptionsDir>

--- a/src/test/resources/unit/javadocjar-invalid-destdir/javadocjar-invalid-destdir-plugin-config.xml
+++ b/src/test/resources/unit/javadocjar-invalid-destdir/javadocjar-invalid-destdir-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.JavadocJarInvalidDestdirMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <destDir>${basedir}/target/test/unit/javadocjar-invalid-destdir/target/invalid</destDir>
           <jarOutputDirectory>${basedir}/target/test/unit/javadocjar-invalid-destdir/target</jarOutputDirectory>
           <outputDirectory>${basedir}/target/test/unit/javadocjar-invalid-destdir/target/site/apidocs</outputDirectory>

--- a/src/test/resources/unit/jdk5-test/jdk5-test-plugin-config.xml
+++ b/src/test/resources/unit/jdk5-test/jdk5-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.Jdk5TestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/jdk5-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/jdk5-test/target/javadoc-bundle-options</javadocOptionsDir>
           <show>protected</show>

--- a/src/test/resources/unit/jdk6-test/jdk6-test-plugin-config.xml
+++ b/src/test/resources/unit/jdk6-test/jdk6-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.Jdk6TestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/jdk6-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/jdk6-test/target/javadoc-bundle-options</javadocOptionsDir>
           <show>protected</show>

--- a/src/test/resources/unit/newline-test/newline-test-plugin-config.xml
+++ b/src/test/resources/unit/newline-test/newline-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.NewlineTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/newline-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/newline-test/target/javadoc-bundle-options</javadocOptionsDir>
           <show>protected</show>

--- a/src/test/resources/unit/optionsumlautencoding-test/optionsumlautencoding-test-plugin-config.xml
+++ b/src/test/resources/unit/optionsumlautencoding-test/optionsumlautencoding-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.OptionsUmlautEncodingMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/optionsumlautencoding-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/optionsumlautencoding-test/target/javadoc-bundle-options</javadocOptionsDir>
           <breakiterator>false</breakiterator>

--- a/src/test/resources/unit/pom-test/pom-test-plugin-config.xml
+++ b/src/test/resources/unit/pom-test/pom-test-plugin-config.xml
@@ -40,7 +40,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.PomMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/pom-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/pom-test/target/javadoc-bundle-options</javadocOptionsDir>
           <show>protected</show>

--- a/src/test/resources/unit/proxy-test/proxy-test-plugin-config.xml
+++ b/src/test/resources/unit/proxy-test/proxy-test-plugin-config.xml
@@ -35,7 +35,6 @@ under the License.
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.ProxyTestMavenProjectStub"/>
           <settings implementation="org.apache.maven.plugins.javadoc.stubs.SettingsStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/proxy-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/proxy-test/target/javadoc-bundle-options</javadocOptionsDir>
           <show>protected</show>

--- a/src/test/resources/unit/quotedpath'test/quotedpath-test-plugin-config.xml
+++ b/src/test/resources/unit/quotedpath'test/quotedpath-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.QuotedPathMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/quotedpath'test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/quotedpath'test/target/javadoc-bundle-options</javadocOptionsDir>
           <breakiterator>false</breakiterator>

--- a/src/test/resources/unit/resources-test/resources-test-plugin-config.xml
+++ b/src/test/resources/unit/resources-test/resources-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.ResourcesTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/resources-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/resources-test/target/javadoc-bundle-options</javadocOptionsDir>
           <windowtitle>Maven Javadoc Plugin resources 1.0-SNAPSHOT API</windowtitle>

--- a/src/test/resources/unit/resources-with-excludes-test/resources-with-excludes-test-plugin-config.xml
+++ b/src/test/resources/unit/resources-with-excludes-test/resources-with-excludes-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.ResourcesWithExcludesTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/resources-with-excludes-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/resources-with-excludes-test/target/javadoc-bundle-options</javadocOptionsDir>
           <windowtitle>Maven Javadoc Plugin resources 1.0-SNAPSHOT API</windowtitle>

--- a/src/test/resources/unit/stylesheetfile-test/artifact-stylesheetfile/org/apache/maven/plugins/maven-javadoc-plugin/unit/stylesheetfile-test/1.0-SNAPSHOT/stylesheetfile-test-1.0-SNAPSHOT.pom
+++ b/src/test/resources/unit/stylesheetfile-test/artifact-stylesheetfile/org/apache/maven/plugins/maven-javadoc-plugin/unit/stylesheetfile-test/1.0-SNAPSHOT/stylesheetfile-test-1.0-SNAPSHOT.pom
@@ -35,7 +35,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.StylesheetFileMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/stylesheetfile-test/target/site/apidocs</outputDirectory>
           <javadocDirectory>${basedir}/src/test/resources/unit/stylesheetfile-test/src/main/javadoc</javadocDirectory>
           <breakiterator>false</breakiterator>

--- a/src/test/resources/unit/stylesheetfile-test/pom.xml
+++ b/src/test/resources/unit/stylesheetfile-test/pom.xml
@@ -35,7 +35,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.StylesheetFileMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/stylesheetfile-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/stylesheetfile-test/target/javadoc-bundle-options</javadocOptionsDir>
           <javadocDirectory>${basedir}/src/test/resources/unit/stylesheetfile-test/src/main/javadoc</javadocDirectory>

--- a/src/test/resources/unit/subpackages-test/subpackages-test-plugin-config.xml
+++ b/src/test/resources/unit/subpackages-test/subpackages-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.SubpackagesTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/subpackages-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/subpackages-test/target/javadoc-bundle-options</javadocOptionsDir>
           <breakiterator>false</breakiterator>

--- a/src/test/resources/unit/tag-test/tag-test-plugin-config.xml
+++ b/src/test/resources/unit/tag-test/tag-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.TagTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/tag-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/tag-test/target/javadoc-bundle-options</javadocOptionsDir>
           <windowtitle>Maven Javadoc Plugin tag 1.0-SNAPSHOT API</windowtitle>

--- a/src/test/resources/unit/taglet-test/taglet-test-plugin-config.xml
+++ b/src/test/resources/unit/taglet-test/taglet-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.TagletTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/taglet-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/taglet-test/target/javadoc-bundle-options</javadocOptionsDir>
           <taglet>org.tullmann.taglets.ToDo</taglet>

--- a/src/test/resources/unit/tagletArtifacts-test/tagletArtifacts-test-plugin-config.xml
+++ b/src/test/resources/unit/tagletArtifacts-test/tagletArtifacts-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.TagletArtifactsMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/tagletArtifacts-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/tagletArtifacts-test/target/javadoc-bundle-options</javadocOptionsDir>
           <breakiterator>false</breakiterator>

--- a/src/test/resources/unit/test-javadoc-test/test-javadoc-test-plugin-config.xml
+++ b/src/test/resources/unit/test-javadoc-test/test-javadoc-test-plugin-config.xml
@@ -40,7 +40,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.TestJavadocMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/test-javadoc-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/test-javadoc-test/target/javadoc-bundle-options</javadocOptionsDir>
           <windowtitle>Maven Test Javadoc Plugin aggregate resources 1.0-SNAPSHOT API</windowtitle>

--- a/src/test/resources/unit/validate-options-test/conflict-options-test-plugin-config.xml
+++ b/src/test/resources/unit/validate-options-test/conflict-options-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.StandardDocletConflictOptionsTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/validate-options-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/validate-options-test/target/javadoc-bundle-options</javadocOptionsDir>
           <show>protected</show>

--- a/src/test/resources/unit/validate-options-test/wrong-charset-test-plugin-config.xml
+++ b/src/test/resources/unit/validate-options-test/wrong-charset-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.WrongEncodingOptionsTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/validate-options-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/validate-options-test/target/javadoc-bundle-options</javadocOptionsDir>
           <show>protected</show>

--- a/src/test/resources/unit/validate-options-test/wrong-docencoding-test-plugin-config.xml
+++ b/src/test/resources/unit/validate-options-test/wrong-docencoding-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.WrongEncodingOptionsTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/validate-options-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/validate-options-test/target/javadoc-bundle-options</javadocOptionsDir>
           <show>protected</show>

--- a/src/test/resources/unit/validate-options-test/wrong-encoding-test-plugin-config.xml
+++ b/src/test/resources/unit/validate-options-test/wrong-encoding-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.WrongEncodingOptionsTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/validate-options-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/validate-options-test/target/javadoc-bundle-options</javadocOptionsDir>
           <show>protected</show>

--- a/src/test/resources/unit/validate-options-test/wrong-locale-test-plugin-config.xml
+++ b/src/test/resources/unit/validate-options-test/wrong-locale-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.WrongEncodingOptionsTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/validate-options-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/validate-options-test/target/javadoc-bundle-options</javadocOptionsDir>
           <show>protected</show>

--- a/src/test/resources/unit/validate-options-test/wrong-locale-with-variant-test-plugin-config.xml
+++ b/src/test/resources/unit/validate-options-test/wrong-locale-with-variant-test-plugin-config.xml
@@ -34,7 +34,6 @@ under the License.
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <project implementation="org.apache.maven.plugins.javadoc.stubs.WrongEncodingOptionsTestMavenProjectStub"/>
-          <localRepository>${localRepository}</localRepository>
           <outputDirectory>${basedir}/target/test/unit/validate-options-test/target/site/apidocs</outputDirectory>
           <javadocOptionsDir>${basedir}/target/test/unit/validate-options-test/target/javadoc-bundle-options</javadocOptionsDir>
           <show>protected</show>


### PR DESCRIPTION
The type is deprecated and parameter is redundant as LRM that is already present has the value.

---

https://issues.apache.org/jira/browse/MJAVADOC-743