### PR TITLE
Bump jetty from 9.4.50.v20221201 to 9.4.51.v20230217

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@ under the License.
     <aetherVersion>1.0.0.v20140518</aetherVersion>
     <!-- https://cwiki.apache.org/confluence/x/VIHOCg#MavenEcosystemCleanup-ResolverandMaven -->
     <plexus-java.version>1.1.2</plexus-java.version>
-    <jetty.version>9.4.50.v20221201</jetty.version>
+    <jetty.version>9.4.51.v20230217</jetty.version>
     <!-- for ITs -->
     <sitePluginVersion>3.12.1</sitePluginVersion>
     <projectInfoReportsPluginVersion>3.4.2</projectInfoReportsPluginVersion>


### PR DESCRIPTION
Closes low-priority CVE-2023-26049 Dependabot report

