### PR TITLE
[MJAVADOC-769] fix for transitive filename based modules

### DIFF
--- a/src/it/projects/MJAVADOC-769/invoker.properties
+++ b/src/it/projects/MJAVADOC-769/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals= clean package
+invoker.java.version = 9+

--- a/src/it/projects/MJAVADOC-769/pom.xml
+++ b/src/it/projects/MJAVADOC-769/pom.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.javadoc.it</groupId>
+  <artifactId>mjavadoc769</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <url>https://issues.apache.org/jira/browse/MJAVADOC-769</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>9</maven.compiler.source>
+    <maven.compiler.target>9</maven.compiler.target>
+    <moduleName>mavenbugs.mjavadoc769</moduleName>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.10.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <version>5.1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>31.1-jre</version>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+      <version>2.0.1.MR</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>@project.version@</version>
+          <configuration>
+            <outputDirectory>${project.build.directory}/apidocs
+            </outputDirectory>
+            <release>11</release>
+            <nodeprecated>false</nodeprecated>
+            <author>false</author>
+            <nohelp>true</nohelp>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.3.0</version>
+          <executions>
+            <execution>
+              <id>default-jar</id>
+              <!-- add module name to main artifact -->
+              <configuration>
+                <archive>
+                  <manifestEntries
+                    combine.children="append">
+                    <Automatic-Module-Name>
+                      ${moduleName}
+                    </Automatic-Module-Name>
+                  </manifestEntries>
+                </archive>
+              </configuration>
+            </execution>
+            <execution>
+              <id>test-jar</id>
+              <!-- add module name to test artifact -->
+              <configuration>
+                <archive>
+                  <manifestEntries
+                    combine.children="append">
+                    <Automatic-Module-Name>
+                      ${moduleName}.tests
+                    </Automatic-Module-Name>
+                  </manifestEntries>
+                </archive>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>javadoc-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>test-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/MJAVADOC-769/src/main/java/mavenbugs/mjavadoc769/InternalImportBindingBuilder.java
+++ b/src/it/projects/MJAVADOC-769/src/main/java/mavenbugs/mjavadoc769/InternalImportBindingBuilder.java
@@ -1,0 +1,116 @@
+package mavenbugs.mjavadoc769;
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.lang.annotation.Annotation;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Provider;
+import com.google.inject.Scope;
+import com.google.inject.TypeLiteral;
+import com.google.inject.binder.LinkedBindingBuilder;
+import com.google.inject.binder.ScopedBindingBuilder;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * Import binding builder.
+ */
+public final class InternalImportBindingBuilder<T> implements ScopedBindingBuilder {
+
+    private final Key<T> concreteType;
+    private final ScopedBindingBuilder binder;
+    private final InternalBindingProvider<T> provider;
+
+    public InternalImportBindingBuilder(LinkedBindingBuilder<T> binder, Key<T> concreteType) {
+        checkNotNull(binder, "binder is null");
+
+        this.concreteType = checkNotNull(concreteType, "concreteType is null");
+
+        this.provider = new InternalBindingProvider<>(concreteType);
+        this.binder = binder.toProvider(provider);
+    }
+
+    /**
+     * Bind a different type as the given binding. This allows binding e.g. implementations to interface types.
+     */
+    public ScopedBindingBuilder to(Class<? extends T> clazz) {
+        checkNotNull(clazz, "clazz is null");
+
+        this.provider.setKey(concreteType.ofType(clazz));
+
+        return this;
+    }
+
+    /**
+     * Bind a different type as the given binding. This allows binding e.g. implementations to interface types.
+     */
+    public ScopedBindingBuilder to(TypeLiteral<? extends T> type) {
+        checkNotNull(type, "type is null");
+
+        this.provider.setKey(concreteType.ofType(type));
+
+        return this;
+    }
+
+    @Override
+    public void in(Class<? extends Annotation> scopeAnnotation) {
+        checkNotNull(scopeAnnotation, "scopeAnnotation is null");
+        this.binder.in(scopeAnnotation);
+    }
+
+    @Override
+    public void in(Scope scope) {
+        checkNotNull(scope, "scope is null");
+        this.binder.in(scope);
+    }
+
+    @Override
+    public void asEagerSingleton() {
+        this.binder.asEagerSingleton();
+    }
+
+    static final class InternalBindingProvider<T> implements Provider<T> {
+
+        private Key<? extends T> key;
+        private Injector injector;
+
+        InternalBindingProvider(Key<? extends T> key) {
+            this.key = checkNotNull(key, "key is null");
+        }
+
+        InternalBindingProvider<T> setKey(Key<? extends T> key) {
+            this.key = checkNotNull(key, "key is null");
+            return this;
+        }
+
+        @Inject
+        void setInjector(final Injector injector) {
+            checkNotNull(injector, "injector is null");
+            checkState(this.injector == null, "setInjector() called multiple times!");
+
+            this.injector = injector;
+        }
+
+        @Override
+        public T get() {
+            checkState(this.injector != null, "calling get() before setInjector()!");
+            return injector.getInstance(key);
+        }
+    }
+}

--- a/src/it/projects/MJAVADOC-769/src/test/java/mavenbugs/mjavadoc769/Right.java
+++ b/src/it/projects/MJAVADOC-769/src/test/java/mavenbugs/mjavadoc769/Right.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package mavenbugs.mjavadoc769;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@javax.inject.Qualifier
+@jakarta.inject.Qualifier
+public @interface Right {}

--- a/src/it/projects/MJAVADOC-769/src/test/java/mavenbugs/mjavadoc769/RightTest.java
+++ b/src/it/projects/MJAVADOC-769/src/test/java/mavenbugs/mjavadoc769/RightTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package mavenbugs.mjavadoc769;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+public class RightTest {
+
+  @Test
+  public void testFoo() throws Exception {
+    Method method = Foo.class.getMethod("foo");
+    Annotation annotation = method.getAnnotation(Right.class);
+    assertNotNull(annotation);
+  }
+
+  @Test
+  public void testRight() throws Exception {
+    Annotation[] annotations = Right.class.getAnnotations();
+    assertEquals(4, annotations.length);
+
+    assertEquals(javax.inject.Qualifier.class, Right.class.getAnnotation(javax.inject.Qualifier.class).annotationType());
+    assertEquals(jakarta.inject.Qualifier.class, Right.class.getAnnotation(jakarta.inject.Qualifier.class).annotationType());
+  }
+
+
+  public static class Foo {
+    @Right
+    public void foo() {
+    }
+  }
+}

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -4554,8 +4554,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
                         ModuleNameSource depModuleNameSource = locationManager
                                 .resolvePath(ResolvePathRequest.ofFile(file))
                                 .getModuleNameSource();
-                        if (ModuleNameSource.MODULEDESCRIPTOR.equals(depModuleNameSource)
-                                || ModuleNameSource.MANIFEST.equals(depModuleNameSource)) {
+                        if (ModuleNameSource.MODULEDESCRIPTOR.equals(depModuleNameSource)) {
                             modulePathElements.add(file);
                         } else {
                             patchModules.get(mainModuleName).add(file.toPath());


### PR DESCRIPTION
When a project depends on an artifact with a manifest entry for
Automatic-Module-Name which in turn depends on an artifact that uses the
filename to determine the module name, it will move the former onto the
module path and patch the latter into the main artifact. However, now
the direct dependency on the module path can no longer access the
classes that have been patched only into the main module and javadoc
generation fails.

As the JDK only differentiates between modules with a module descriptor
and "everything else" (modules with an automatic module entry in the
manifest and modules with file name based names), the javadoc plugin
should do the same.

This patch changes the treatment of dependencies with an
Automatic-Module-Name to match dependencies that use a filename based
module name. The plugin now patches all of those dependencies into the
main module and the build succeeds.

Includes an integration test.

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJAVADOC) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue.  Your pull request should address just this issue, without
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify -Prun-its` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
