### PR TITLE
[MJAVADOC-726] update to log4j 1.2.17 in dependency tree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,12 @@ under the License.
         <artifactId>aether-util</artifactId>
         <version>${aetherVersion}</version>
       </dependency>
+      <!-- log4j 1.2.12 is pulled in by commons-logging via Velocity 2 via Doxia 1  -->
+      <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>1.2.17</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Nuked log4j from my .m2/repo and veriifed that the sample project now only downloads 1.2.17 when generating javadoc with 3.6.1-SNAPSHOT with this patch

```
~/mvn-javadoc-issue-sample$ mvn javadoc:javadoc
[INFO] Scanning for projects...
[INFO] 
[INFO] ----------< com.writetoyogi.automation:maven-sample-project >-----------
[INFO] Building maven-sample-project 0.0.1-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] >>> maven-javadoc-plugin:3.6.1-SNAPSHOT:javadoc (default-cli) > generate-sources @ maven-sample-project >>>
[INFO] 
[INFO] <<< maven-javadoc-plugin:3.6.1-SNAPSHOT:javadoc (default-cli) < generate-sources @ maven-sample-project <<<
[INFO] 
[INFO] 
[INFO] --- maven-javadoc-plugin:3.6.1-SNAPSHOT:javadoc (default-cli) @ maven-sample-project ---
Downloading from central: https://repo.maven.apache.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17.pom
Downloaded from central: https://repo.maven.apache.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17.pom (22 kB at 38 kB/s)
[INFO] Configuration changed, re-generating javadoc.
[INFO] 
``

![image](https://github.com/apache/maven-javadoc-plugin/assets/1005544/3712f04f-6700-40de-af7e-72d1d93d6f0d)
