### PR TITLE
[MJAVADOC-726] exclude velocity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,13 @@ under the License.
       <groupId>org.apache.maven.doxia</groupId>
       <artifactId>doxia-site-renderer</artifactId>
       <version>${doxia-sitetoolsVersion}</version>
+      <exclusions>
+        <exclusion>
+          <!-- MJAVADOC-726 -->
+          <groupId>org.apache.velocity</groupId>
+          <artifactId>velocity-tools</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- wagon -->

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -543,7 +543,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
     private boolean detectOfflineLinks;
 
     /**
-     * Detect the Java API link for the current build, i.e. <code>https://docs.oracle.com/javase/1.4.2/docs/api/</code>
+     * Detect the Java API link for the current build, e.g. <code>https://docs.oracle.com/javase/1.4.2/docs/api/</code>
      * for Java source 1.4.
      * <br/>
      * By default, the goal detects the Javadoc API link depending the value of the <code>source</code>
@@ -3767,7 +3767,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
      * If {@code detectLinks}, try to add javadoc apidocs according Maven conventions for all dependencies given
      * in the project.
      * <br/>
-     * According the Javadoc documentation, all defined link should have <code>${link}/package-list</code> fetchable.
+     * According the Javadoc documentation, all defined links should have <code>${link}/package-list</code> fetchable.
      * <br/>
      * <b>Note</b>: when a link is not fetchable:
      * <ul>
@@ -3802,7 +3802,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
     }
 
     /**
-     * Coppy all resources to the output directory
+     * Copy all resources to the output directory.
      *
      * @param javadocOutputDirectory not null
      * @throws MavenReportException if any
@@ -5725,7 +5725,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
             try {
                 redirectLinks.add(JavadocUtil.getRedirectUrl(new URI(link).toURL(), settings)
                         .toString());
-            } catch (Exception e) {
+            } catch (IOException e) {
                 // only print in debug, it should have been logged already in warn/error because link isn't valid
                 getLog().debug("Could not follow " + link + ". Reason: " + e.getMessage());
 
@@ -5733,6 +5733,9 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
                 // incomplete redirect configuration on the server side.
                 // This partially restores the previous behaviour before fix for MJAVADOC-427
                 redirectLinks.add(link);
+            } catch (URISyntaxException | IllegalArgumentException e) {
+                // only print in debug, it should have been logged already in warn/error because link isn't valid
+                getLog().debug("Could not follow " + link + ". Reason: " + e.getMessage());
             }
         }
         return redirectLinks;

--- a/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
@@ -1218,7 +1218,7 @@ public class JavadocUtil {
         return result;
     }
 
-    // TODO: move to plexus-utils or use something appropriate from there
+    // TODO: deprecate in favor of Path.relativize
     public static String toRelative(File basedir, String absolutePath) {
         String relative;
 
@@ -1259,13 +1259,13 @@ public class JavadocUtil {
     }
 
     /**
-     * Execute an Http request at the given URL, follows redirects, and returns the last redirect locations. For URLs
+     * Execute an HTTP request to the given URL, follow redirects, and return the last redirect location. For URLs
      * that aren't http/https, this does nothing and simply returns the given URL unchanged.
      *
-     * @param url URL.
-     * @param settings Maven settings.
-     * @return Last redirect location.
-     * @throws IOException if there was an error during the Http request.
+     * @param url URL
+     * @param settings Maven settings
+     * @return final URL after all redirects have been followed
+     * @throws IOException if there was an error during the HTTP request
      */
     protected static URL getRedirectUrl(URL url, Settings settings) throws IOException {
         String protocol = url.getProtocol();


### PR DESCRIPTION
Alternate approach to keeping log4j out of the tree by excluding velocity-tools.

Nuked log4j from my .m2/repo and verified that the sample project does not download log4j when generating javadoc with 3.6.1-SNAPSHOT with this patch

Tests pass locally