### PR TITLE
[MJAVADOC-775] Option 'taglets/taglet/tagletpath' ignored when pointing to a JAR

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -2962,8 +2962,9 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
                     && (StringUtils.isNotEmpty(taglet.getTagletArtifact().getVersion()))) {
                 pathParts.addAll(JavadocUtil.pruneFiles(getArtifactsAbsolutePath(taglet.getTagletArtifact())));
             } else if (StringUtils.isNotEmpty(taglet.getTagletpath())) {
-                for (Path dir : JavadocUtil.pruneDirs(project, Collections.singletonList(taglet.getTagletpath()))) {
-                    pathParts.add(dir.toString());
+                for (Path path :
+                        JavadocUtil.prunePaths(project, Collections.singletonList(taglet.getTagletpath()), true)) {
+                    pathParts.add(path.toString());
                 }
             }
         }

--- a/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
@@ -118,30 +118,45 @@ public class JavadocUtil {
                     + "environment variable using -Xms:<size> and -Xmx:<size>.";
 
     /**
-     * Method that removes the invalid directories in the specified directories. <b>Note</b>: All elements in
-     * <code>dirs</code> could be an absolute or relative against the project's base directory <code>String</code> path.
+     * Method that removes invalid classpath elements in the specified paths.
+     * <b>Note</b>: All elements in {@code paths} could be absolute or relative against the project's base directory.
+     * When pruning classpath elements, you can optionally include files in the result, otherwise only directories are
+     * permitted.
      *
      * @param project the current Maven project not null
-     * @param dirs the collection of <code>String</code> directories path that will be validated.
-     * @return a List of valid <code>String</code> directories absolute paths.
+     * @param paths the collection of paths that will be validated
+     * @param includeFiles whether to include files in the result as well
+     * @return a list of valid classpath elements as absolute paths
      */
-    public static Collection<Path> pruneDirs(MavenProject project, Collection<String> dirs) {
+    public static Collection<Path> prunePaths(MavenProject project, Collection<String> paths, boolean includeFiles) {
         final Path projectBasedir = project.getBasedir().toPath();
 
-        Set<Path> pruned = new LinkedHashSet<>(dirs.size());
-        for (String dir : dirs) {
-            if (dir == null) {
+        Set<Path> pruned = new LinkedHashSet<>(paths.size());
+        for (String path : paths) {
+            if (path == null) {
                 continue;
             }
 
-            Path directory = projectBasedir.resolve(dir);
+            Path resolvedPath = projectBasedir.resolve(path);
 
-            if (Files.isDirectory(directory)) {
-                pruned.add(directory.toAbsolutePath());
+            if (Files.isDirectory(resolvedPath) || includeFiles && Files.isRegularFile(resolvedPath)) {
+                pruned.add(resolvedPath.toAbsolutePath());
             }
         }
 
         return pruned;
+    }
+
+    /**
+     * Method that removes the invalid classpath directories in the specified directories.
+     * <b>Note</b>: All elements in {@code dirs} could be absolute or relative against the project's base directory.
+     *
+     * @param project the current Maven project not null
+     * @param dirs the collection of directories that will be validated
+     * @return a list of valid claspath elements as absolute paths
+     */
+    public static Collection<Path> pruneDirs(MavenProject project, Collection<String> dirs) {
+        return prunePaths(project, dirs, false);
     }
 
     /**

--- a/src/test/java/org/apache/maven/plugins/javadoc/JavadocUtilTest.java
+++ b/src/test/java/org/apache/maven/plugins/javadoc/JavadocUtilTest.java
@@ -32,9 +32,11 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -582,16 +584,43 @@ public class JavadocUtilTest extends PlexusTestCase {
      */
     public void testPruneDirs() {
         List<String> list = new ArrayList<>();
-        list.add(getBasedir() + "/target/classes");
-        list.add(getBasedir() + "/target/classes");
-        list.add(getBasedir() + "/target/classes");
+        String classesDir = getBasedir() + "/target/classes";
+        list.add(classesDir);
+        list.add(classesDir);
+        list.add(classesDir);
 
-        Set<Path> expected = Collections.singleton(Paths.get(getBasedir(), "target/classes"));
+        Set<Path> expected = Collections.singleton(Paths.get(classesDir));
 
         MavenProjectStub project = new MavenProjectStub();
         project.setFile(new File(getBasedir(), "pom.xml"));
 
         assertEquals(expected, JavadocUtil.pruneDirs(project, list));
+    }
+
+    /**
+     * Method to test prunePaths()
+     *
+     */
+    public void testPrunePaths() {
+        List<String> list = new ArrayList<>();
+        String classesDir = getBasedir() + "/target/classes";
+        String tagletJar = getBasedir()
+                + "/target/test-classes/unit/taglet-test/artifact-taglet/org/tullmann/taglets/1.0/taglets-1.0.jar";
+        list.add(classesDir);
+        list.add(classesDir);
+        list.add(classesDir);
+        list.add(tagletJar);
+        list.add(tagletJar);
+        list.add(tagletJar);
+
+        Set<Path> expectedNoJar = Collections.singleton(Paths.get(classesDir));
+        Set<Path> expectedWithJar = new HashSet<>(Arrays.asList(Paths.get(classesDir), Paths.get(tagletJar)));
+
+        MavenProjectStub project = new MavenProjectStub();
+        project.setFile(new File(getBasedir(), "pom.xml"));
+
+        assertEquals(expectedNoJar, JavadocUtil.prunePaths(project, list, false));
+        assertEquals(expectedWithJar, JavadocUtil.prunePaths(project, list, true));
     }
 
     /**


### PR DESCRIPTION
Fixes [MJAVADOC-775](https://issues.apache.org/jira/browse/MJAVADOC-775).
Fixes [MJAVADOC-783](https://issues.apache.org/jira/browse/MJAVADOC-783).

@elharo, @robjg, @jkesselm

---

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).