### PR TITLE
Fix `addStylesheets` Javadoc

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -1314,7 +1314,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
      * Example:
      * <pre>
      *     &lt;addStylesheets&gt;
-     *         &lt;resources/addstylesheet.css&lt;/addStylesheet&gt;
+     *         &lt;addStylesheet&gt;resources/addstylesheet.css&lt;/addStylesheet&gt;
      *     &lt;/addStylesheets&gt;
      * </pre>
      * @since 3.3.0


### PR DESCRIPTION
This fixes also https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#addStylesheets which is currently rendered as:

<img width="628" alt="Screenshot 2024-01-06 at 13 10 12" src="https://github.com/apache/maven-javadoc-plugin/assets/26772046/9a510a33-f6d4-4c87-8a05-d5077a2971fc">


---
 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

