### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,7 +26,6 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v3
     with:
-      verify-fail-fast: false
       jdk-distribution-matrix: '[ "temurin", "zulu", "microsoft", "liberica", "adopt-openj9" ]'
       matrix-exclude: '[
         { "jdk": "8", "distribution": "microsoft"},

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,5 +26,9 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v3
     with:
+      verify-fail-fast: false
       jdk-distribution-matrix: '[ "temurin", "zulu", "microsoft", "liberica", "adopt-openj9" ]'
-      matrix-exclude: '[{ "jdk": "8", "distribution": "microsoft"}]'
+      matrix-exclude: '[
+        { "jdk": "8", "distribution": "microsoft"},
+        { "jdk": "21", "distribution": "adopt-openj9"}
+      ]'

--- a/src/it/projects/MJAVADOC-427/invoker.properties
+++ b/src/it/projects/MJAVADOC-427/invoker.properties
@@ -18,4 +18,5 @@
 invoker.goals=clean javadoc:javadoc
 
 # slf4j javadoc is hosted on https site with a "let's encrypt" certificate, signed by IdenTrust only trusted since 8u101 (JDK-8154757)
-invoker.java.version = 1.8.0.101+
+# consider to execute on JDK8 after - MJAVADOC-786
+invoker.java.version = 9+


### PR DESCRIPTION
- exclude JDK 21 with adopt-openj9 - it is not present
- disable IT MJAVADOC-427 on JDK 8 - slf4j javadoc is build by JDK 21 - it can not be consumed by javadoc from JDK 8