### PR TITLE
Fix usage documentation mentioning `nohelp` default value

### DIFF
--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -148,7 +148,7 @@ mvn javadoc:test-aggregate-jar
 
  [<<<mvn site>>>] It will generate the Javadoc for public members (defined in \<reporting/\>) using the given
  stylesheet (defined in \<reporting/\>), and with a help page (default value for
- {{{./javadoc-mojo.html#nohelp}nohelp}} is true).
+ {{{./javadoc-mojo.html#nohelp}nohelp}} is false).
 
  [<<<mvn javadoc:javadoc>>>] It will generate the Javadoc for private members (defined in \<build/\>) using the
  stylesheet (defined in \<reporting/\>), and with no help page (defined in \<build/\>).


### PR DESCRIPTION
The "usage" documentation page mention the default value of the `nohelp` parameter being `true`, but it's `false` (https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#nohelp).

 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
