### PR TITLE
Reproducer for different behavior of exclude for java8 and java11

### DIFF
--- a/src/test/java/org/apache/maven/plugins/javadoc/JavadocReportTest.java
+++ b/src/test/java/org/apache/maven/plugins/javadoc/JavadocReportTest.java
@@ -1294,4 +1294,22 @@ public class JavadocReportTest extends AbstractMojoTestCase {
         assertTrue(optionsContent.contains("-helpfile"));
         assertTrue(optionsContent.contains("'" + help.toFile().getAbsolutePath().replaceAll("\\\\", "/") + "'"));
     }
+
+    /** It should include only single class in javadoc. */
+    public void testSubpackagesExcludePackages() throws Exception {
+        Path testPom = unit.resolve("subpackages-exclude-packages-test/pom.xml");
+
+        JavadocReport mojo = lookupMojo(testPom);
+
+        mojo.execute();
+
+        Path apidocs = new File(getBasedir(), "target/test/unit/subpackages-exclude-packages-test/target/site/apidocs").toPath();
+
+        // check if the classes in the specified subpackages were included
+        assertThat(apidocs.resolve("org/apache/project/IncludeClass.html")).exists();
+
+        // check the excluded packages
+        assertThat(apidocs.resolve("org/apache/internal")).doesNotExist();
+        assertThat(apidocs.resolve("io")).doesNotExist();
+    }
 }

--- a/src/test/java/org/apache/maven/plugins/javadoc/stubs/SubpackagesExcludePackagesTestMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/javadoc/stubs/SubpackagesExcludePackagesTestMavenProjectStub.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.javadoc.stubs;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/** */
+public class SubpackagesExcludePackagesTestMavenProjectStub extends MavenProjectStub {
+    public SubpackagesExcludePackagesTestMavenProjectStub() {
+        readModel(new File(getBasedir(), "pom.xml"));
+
+        setGroupId(getModel().getGroupId());
+        setArtifactId(getModel().getArtifactId());
+        setVersion(getModel().getVersion());
+
+        setName(getModel().getName());
+        setUrl(getModel().getUrl());
+        setPackaging(getModel().getPackaging());
+
+        Build build = new Build();
+        build.setFinalName(getName());
+        build.setDirectory(super.getBasedir() + "/target/test/unit/subpackages-exclude-packages-test/target");
+        setBuild(build);
+
+        List<String> compileSourceRoots = new ArrayList<>();
+        compileSourceRoots.add(getBasedir() + "/src/main/java");
+        setCompileSourceRoots(compileSourceRoots);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public File getBasedir() {
+        return new File(super.getBasedir() + "/src/test/resources/unit/subpackages-exclude-packages-test");
+    }
+}

--- a/src/test/resources/unit/subpackages-exclude-packages-test/pom.xml
+++ b/src/test/resources/unit/subpackages-exclude-packages-test/pom.xml
@@ -1,0 +1,59 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.unit</groupId>
+  <artifactId>subpackages-exclude-packages-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+
+        <configuration>
+          <project implementation="org.apache.maven.plugins.javadoc.stubs.SubpackagesExcludePackagesTestMavenProjectStub"/>
+
+          <outputDirectory>${basedir}/target/test/unit/subpackages-exclude-packages-test/target/site/apidocs</outputDirectory>
+          <javadocOptionsDir>${basedir}/target/test/unit/subpackages-exclude-packages-test/target/javadoc-bundle-options</javadocOptionsDir>
+
+          <!-- Comment the next line, and javadoc will skip all subpackages under "internal" package -->
+          <subpackages>org.apache</subpackages>
+
+          <excludePackageNames>
+            org.apache.internal
+            :org.apache.internal.*
+          </excludePackageNames>
+
+          <debug>true</debug>
+
+          <reactorProjects>
+            <project implementation="org.apache.maven.plugins.javadoc.stubs.SubpackagesExcludePackagesTestMavenProjectStub"/>
+          </reactorProjects>
+
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/unit/subpackages-exclude-packages-test/src/main/java/io/ExcludeIoClass.java
+++ b/src/test/resources/unit/subpackages-exclude-packages-test/src/main/java/io/ExcludeIoClass.java
@@ -1,0 +1,36 @@
+package io;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Class to be excluded.
+ */
+public class ExcludeIoClass
+{
+    /**
+     * Sample method that prints out the parameter string.
+     *
+     * @param str   The string value to be printed.
+     */
+    public void sampleMethod( String str )
+    {
+        System.out.println( str );
+    }
+}

--- a/src/test/resources/unit/subpackages-exclude-packages-test/src/main/java/org/apache/internal/ExcludeInternalClass.java
+++ b/src/test/resources/unit/subpackages-exclude-packages-test/src/main/java/org/apache/internal/ExcludeInternalClass.java
@@ -1,0 +1,39 @@
+package org.apache.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Class to be excluded.
+ */
+public class ExcludeInternalClass
+{
+    /**
+     * Sample method that prints out the parameter string.
+     *
+     * @param str   The string value to be printed.
+     */
+    public void sampleMethod( String str )
+    {
+        System.out.println( str );
+    }
+}

--- a/src/test/resources/unit/subpackages-exclude-packages-test/src/main/java/org/apache/internal/subpackage/ExcludeInternalSubClass.java
+++ b/src/test/resources/unit/subpackages-exclude-packages-test/src/main/java/org/apache/internal/subpackage/ExcludeInternalSubClass.java
@@ -1,0 +1,36 @@
+package org.apache.internal.subpackage;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Class to be excluded.
+ */
+public class ExcludeInternalSubClass
+{
+    /**
+     * Sample method that prints out the parameter string.
+     *
+     * @param str   The string value to be printed.
+     */
+    public void sampleMethod( String str )
+    {
+        System.out.println( str );
+    }
+}

--- a/src/test/resources/unit/subpackages-exclude-packages-test/src/main/java/org/apache/internal/subpackage/subsubpackage/ExcludeInternalSubSubClass.java
+++ b/src/test/resources/unit/subpackages-exclude-packages-test/src/main/java/org/apache/internal/subpackage/subsubpackage/ExcludeInternalSubSubClass.java
@@ -1,0 +1,36 @@
+package org.apache.internal.subpackage.subsubpackage;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Class to be excluded.
+ */
+public class ExcludeInternalSubSubClass
+{
+    /**
+     * Sample method that prints out the parameter string.
+     *
+     * @param str   The string value to be printed.
+     */
+    public void sampleMethod( String str )
+    {
+        System.out.println( str );
+    }
+}

--- a/src/test/resources/unit/subpackages-exclude-packages-test/src/main/java/org/apache/project/IncludeClass.java
+++ b/src/test/resources/unit/subpackages-exclude-packages-test/src/main/java/org/apache/project/IncludeClass.java
@@ -1,0 +1,36 @@
+package org.apache.project;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Class to be included.
+ */
+public class IncludeClass
+{
+    /**
+     * Sample method that prints out the parameter string.
+     *
+     * @param str   The string value to be printed.
+     */
+    public void sampleMethod( String str )
+    {
+        System.out.println( str );
+    }
+}


### PR DESCRIPTION
In the test I want to prepare javadocs only for the class **org.apache.project.IncludeClass**. All other classes located in packages **io** and **org.apache.internal** should be skipped.

Configuration I use is the following:
```
          <subpackages>org.apache</subpackages>
          <excludePackageNames>org.apache.internal:org.apache.internal.*</excludePackageNames>
```

It works well for java8, but for java11 (actually since java9) it doesn't filter the class **org.apache.internal.subpackage.subsubpackage.ExcludeInternalSubSubClass**. 

I tried comment the "subpackages" setting and it filters the **ExcludeInternalSubSubClass**, but obviously prepares docs for the **io.ExcludedIoClass**. This behavior is pretty non straightforward for me, I expect that filtering rules should not depend on the subpackages setting.

I debug it and found:
1. Behavior for filtering is actually differs depending whether the "subpackages" setting is specified or not - there are different patterns for exclusion used, see patterns in **JavadocUtil#getExcludedPackages** and **JavadocUtil#getIncludedFiles**.
2. If the subpackages setting is used, the plugin prepares equal options for the javadoc util for both java versions. But actually the output for the javadoc util differs. I'm not sure is it correct?  
