### PR TITLE
[MJAVADOC-798] pass user settings to invoker

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractFixJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractFixJavadocMojo.java
@@ -655,7 +655,8 @@ public abstract class AbstractFixJavadocMojo extends AbstractMojo {
                 Collections.singletonList(clirrGoal),
                 properties,
                 invokerLogFile,
-                session.getRequest().getGlobalSettingsFile());
+                session.getRequest().getGlobalSettingsFile(),
+                session.getRequest().getUserSettingsFile());
 
         try {
             if (invokerLogFile.exists()) {

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -5514,7 +5514,8 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
                             Collections.singletonList(javadocGoal),
                             null,
                             invokerLogFile,
-                            session.getRequest().getGlobalSettingsFile());
+                            session.getRequest().getGlobalSettingsFile(),
+                            session.getRequest().getUserSettingsFile());
                 } catch (MavenInvocationException e) {
                     logError("MavenInvocationException: " + e.getMessage(), e);
 

--- a/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
@@ -714,6 +714,7 @@ public class JavadocUtil {
      * @param properties the properties for the goals, could be null.
      * @param invokerLog the log file where the invoker will be written, if null using <code>System.out</code>.
      * @param globalSettingsFile reference to settings file, could be null.
+     * @param userSettingsFile reference to user settings file, could be null.
      * @throws MavenInvocationException if any
      * @since 2.6
      */
@@ -724,7 +725,8 @@ public class JavadocUtil {
             List<String> goals,
             Properties properties,
             File invokerLog,
-            File globalSettingsFile)
+            File globalSettingsFile,
+            File userSettingsFile)
             throws MavenInvocationException {
         if (projectFile == null) {
             throw new IllegalArgumentException("projectFile should be not null.");
@@ -760,6 +762,7 @@ public class JavadocUtil {
         request.setBaseDirectory(projectFile.getParentFile());
         request.setPomFile(projectFile);
         request.setGlobalSettingsFile(globalSettingsFile);
+        request.setUserSettingsFile(userSettingsFile);
         request.setBatchMode(true);
         if (log != null) {
             request.setDebug(log.isDebugEnabled());

--- a/src/test/java/org/apache/maven/plugins/javadoc/FixJavadocMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/javadoc/FixJavadocMojoTest.java
@@ -540,7 +540,7 @@ public class FixJavadocMojoTest extends AbstractMojoTestCase {
         Properties properties = new Properties();
 
         JavadocUtil.invokeMaven(
-                log, new File(getBasedir(), "target/local-repo"), testPom, goals, properties, invokerLogFile, null);
+                log, new File(getBasedir(), "target/local-repo"), testPom, goals, properties, invokerLogFile, null, null);
     }
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
Fixes MJAVADOC-798 to avoid dependency downloading problems due to ignoring user settings.

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJAVADOC) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue.  Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify -Prun-its` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.

 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).