### PR TITLE
[MJAVADOC-799] Remove inconsistent `AbstractFixJavadocMojo#defaultVersion` default value

### DIFF
--- a/src/it/projects/javadoc-fix/verify.bsh
+++ b/src/it/projects/javadoc-fix/verify.bsh
@@ -60,13 +60,13 @@ try
     content = FileUtils.fileRead( javaFile, "UTF-8" );
 
     assertContains( content, " * <p>ClassWithNoJavadoc class.</p>" );
-    assertContains( content, " * @version $Id: $" );
     assertContains( content, " * @since 1.0" );
     assertContains( content, "     * <p>main.</p>" );
     assertContains( content, "     * @param args an array of {@link java.lang.String} objects" );
     // private sampleMethod
     assertNotContains( content, "     * <p>sampleMethod.</p>" );
     assertNotContains( content, "     * @param str a {@link java.lang.String} object" );
+    assertNotContains( content, " * @version " );
 
     javaFile = new File( basedir, "/src/main/java/fix/test/ClassWithJavadoc.java" );
     content = FileUtils.fileRead( javaFile, "UTF-8" );
@@ -93,21 +93,21 @@ try
     content = FileUtils.fileRead( javaFile, "UTF-8" );
 
     assertContains( content, " * <p>InterfaceWithNoJavadoc interface.</p>" );
-    assertContains( content, " * @version $Id: $" );
     assertContains( content, " * @since 1.0" );
     assertContains( content, "    /** Constant <code>MY_STRING_CONSTANT=\"value\"</code> */" );
     assertContains( content, "     * <p>method.</p>" );
     assertContains( content, "     * @param aString a {@link java.lang.String} object" );
+    assertNotContains( content, " * @version " );
 
     javaFile = new File( basedir, "/src/main/java/fix/test/InterfaceWithJavadoc.java" );
     content = FileUtils.fileRead( javaFile, "UTF-8" );
 
     assertContains( content, " * Some Javadoc." );
-    assertContains( content, " * @version $Id: $" );
     assertContains( content, " * @since 1.0" );
     assertContains( content, "    /** comment */" );
     assertContains( content, "     * My method" );
     assertContains( content, "     * @param aString a {@link java.lang.String} object" );
+    assertNotContains( content, " * @version " );
 
 }
 catch( Throwable e )

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractFixJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractFixJavadocMojo.java
@@ -207,11 +207,6 @@ public abstract class AbstractFixJavadocMojo extends AbstractMojo {
      */
     public static final String JAVA_FILES = "**\\/*.java";
 
-    /**
-     * Default version value.
-     */
-    public static final String DEFAULT_VERSION_VALUE = "\u0024Id: \u0024Id";
-
     // ----------------------------------------------------------------------
     // Mojo components
     // ----------------------------------------------------------------------
@@ -251,13 +246,9 @@ public abstract class AbstractFixJavadocMojo extends AbstractMojo {
 
     /**
      * Default value for the Javadoc tag <code>&#64;version</code>.
-     * <br/>
-     * By default, it is <code>&#36;Id:&#36;</code>, corresponding to a
-     * <a href="http://svnbook.red-bean.com/en/1.1/ch07s02.html#svn-ch-7-sect-2.3.4">SVN keyword</a>.
-     * Refer to your SCM to use an other SCM keyword.
      */
-    @Parameter(property = "defaultVersion", defaultValue = DEFAULT_VERSION_VALUE)
-    private String defaultVersion = "\u0024Id: \u0024"; // can't use default-value="\u0024Id: \u0024"
+    @Parameter(property = "defaultVersion")
+    private String defaultVersion;
 
     /**
      * The file encoding to use when reading the source files. If the property
@@ -286,7 +277,7 @@ public abstract class AbstractFixJavadocMojo extends AbstractMojo {
      * <li>link (fix only &#64;link tag)</li>
      * </ul>
      */
-    @Parameter(property = "fixTags", defaultValue = "all")
+    @Parameter(property = "fixTags", defaultValue = FIX_TAGS_ALL)
     private String fixTags;
 
     /**
@@ -346,7 +337,7 @@ public abstract class AbstractFixJavadocMojo extends AbstractMojo {
      * </ul>
      * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/man/javadoc.html#options-for-javadoc">private, protected, public, package options for Javadoc</a>
      */
-    @Parameter(property = "level", defaultValue = "protected")
+    @Parameter(property = "level", defaultValue = LEVEL_PROTECTED)
     private String level;
 
     /**
@@ -2109,7 +2100,7 @@ public abstract class AbstractFixJavadocMojo extends AbstractMojo {
      * @return true if separator has been added.
      */
     private boolean appendDefaultVersionTag(final StringBuilder sb, final String indent, boolean separatorAdded) {
-        if (!fixTag(VERSION_TAG)) {
+        if (!fixTag(VERSION_TAG) || StringUtils.isEmpty(defaultVersion)) {
             return separatorAdded;
         }
 
@@ -2127,7 +2118,7 @@ public abstract class AbstractFixJavadocMojo extends AbstractMojo {
      * @param indent not null
      */
     private void appendDefaultVersionTag(final StringBuilder sb, final String indent) {
-        if (!fixTag(VERSION_TAG)) {
+        if (!fixTag(VERSION_TAG) || StringUtils.isEmpty(defaultVersion)) {
             return;
         }
 

--- a/src/test/resources/unit/fix-test/expected/src/main/java/fix/test/ClassWithJavadoc.java
+++ b/src/test/resources/unit/fix-test/expected/src/main/java/fix/test/ClassWithJavadoc.java
@@ -23,7 +23,6 @@ package fix.test;
  * To add default class tags.
  *
  * @author <a href="mailto:vsiveton@apache.org">vsiveton@apache.org</a>
- * @version $Id: $
  */
 @SuppressWarnings("SameReturnValue")
 public class ClassWithJavadoc

--- a/src/test/resources/unit/fix-test/expected/src/main/java/fix/test/ClassWithNoJavadoc.java
+++ b/src/test/resources/unit/fix-test/expected/src/main/java/fix/test/ClassWithNoJavadoc.java
@@ -25,7 +25,6 @@ import java.util.Map;
  * <p>ClassWithNoJavadoc class.</p>
  *
  * @author <a href="mailto:vsiveton@apache.org">vsiveton@apache.org</a>
- * @version $Id: $
  */
 @SuppressWarnings("SameReturnValue")
 public class ClassWithNoJavadoc

--- a/src/test/resources/unit/fix-test/expected/src/main/java/fix/test/InterfaceWithJavadoc.java
+++ b/src/test/resources/unit/fix-test/expected/src/main/java/fix/test/InterfaceWithJavadoc.java
@@ -23,7 +23,6 @@ package fix.test;
  * To add default interface tags.
  *
  * @author <a href="mailto:vsiveton@apache.org">vsiveton@apache.org</a>
- * @version $Id: $
  */
 public interface InterfaceWithJavadoc
 {

--- a/src/test/resources/unit/fix-test/expected/src/main/java/fix/test/InterfaceWithNoJavadoc.java
+++ b/src/test/resources/unit/fix-test/expected/src/main/java/fix/test/InterfaceWithNoJavadoc.java
@@ -23,7 +23,6 @@ package fix.test;
  * <p>InterfaceWithNoJavadoc interface.</p>
  *
  * @author <a href="mailto:vsiveton@apache.org">vsiveton@apache.org</a>
- * @version $Id: $
  */
 public interface InterfaceWithNoJavadoc
 {


### PR DESCRIPTION
As mentioned in [MJAVADOC-799](https://issues.apache.org/jira/browse/MJAVADOC-799) there is currently a mismatch for the `AbstractFixJavadocMojo#defaultVersion` parameter default value:
- documented value: `$Id:$`
- initial field value: `$Id: $`
- `@Parameter#defaultValue`: `$Id: $Id`

It seems `@Parameter#defaultValue` overwrites the initial field value. This can be seen when running `mvn org.apache.maven.plugins:maven-javadoc-plugin:3.7.0:fix` on a dummy project; it will add `@version $Id: $Id` to the Javadoc.

As mentioned in the Jira issue I am not sure if `$Id: $Id` is really a good / the intended default value, but it is the value currently used by the Mojo, therefore I have kept it. And I have adjusted the expected unit test results because they don't seem to create the Mojo instance the way Maven normally does, and are therefore using the initial field value (which was previously incorrect) instead of `@Parameter#defaultValue`.

I have also included some small changes for URLs and `defaultValue` for other parameters. Please let me know if I should omit that because it is not directly related to this.

----

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJAVADOC) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue.  Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify -Prun-its` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

