### PR TITLE
Add test for custom `FixJavadocMojo#defaultVersion`

### DIFF
--- a/src/it/projects/javadoc-fix-version/invoker.properties
+++ b/src/it/projects/javadoc-fix-version/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=clean compile javadoc:fix

--- a/src/it/projects/javadoc-fix-version/pom.xml
+++ b/src/it/projects/javadoc-fix-version/pom.xml
@@ -1,0 +1,60 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
+  <artifactId>javadoc-fix-version</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>@maven.compiler.source@</maven.compiler.source>
+    <maven.compiler.target>@maven.compiler.target@</maven.compiler.target>
+  </properties>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <directory>target</directory>
+    <sourceDirectory>src/main/java</sourceDirectory>
+    <outputDirectory>target/classes</outputDirectory>
+    <finalName>${artifactId}-${version}</finalName>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@compilerPluginVersion@</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <force>true</force>
+          <ignoreClirr>true</ignoreClirr>
+          <fixTags>version</fixTags>
+          <defaultVersion>1.2.3</defaultVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/javadoc-fix-version/src/main/java/fix/test/ClassWithJavadoc.java
+++ b/src/it/projects/javadoc-fix-version/src/main/java/fix/test/ClassWithJavadoc.java
@@ -1,0 +1,33 @@
+package fix.test;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Some Javadoc.
+ */
+public class ClassWithJavadoc
+{
+    /**
+     * Nested
+     */
+    public static class NestedClass
+    {
+    }
+}

--- a/src/it/projects/javadoc-fix-version/src/main/java/fix/test/ClassWithJavadocAndVersion.java
+++ b/src/it/projects/javadoc-fix-version/src/main/java/fix/test/ClassWithJavadocAndVersion.java
@@ -1,0 +1,29 @@
+package fix.test;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Some Javadoc.
+ *
+ * @version 5.6.7
+ */
+public class ClassWithJavadocAndVersion
+{
+}

--- a/src/it/projects/javadoc-fix-version/src/main/java/fix/test/ClassWithNoJavadoc.java
+++ b/src/it/projects/javadoc-fix-version/src/main/java/fix/test/ClassWithNoJavadoc.java
@@ -1,0 +1,27 @@
+package fix.test;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class ClassWithNoJavadoc
+{
+    public static class NestedClass
+    {
+    }
+}

--- a/src/it/projects/javadoc-fix-version/verify.bsh
+++ b/src/it/projects/javadoc-fix-version/verify.bsh
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+import org.codehaus.plexus.util.*;
+
+assertLines( String fileName, int start, String[] expectedLines )
+{
+    File javaFile = new File( basedir, "/src/main/java/fix/test/" + fileName );
+    String content = FileUtils.fileRead( javaFile, "UTF-8" );
+    String[] lines = content.split( "\\R" );
+    if ( start + expectedLines.length >= lines.length )
+    {
+        throw new IllegalArgumentException( "too few lines for " + fileName + ", expected: " + Arrays.toString( expectedLines ) );
+    }
+
+    for ( int i = 0; i < expectedLines.length; i++ )
+    {
+        String line = lines[ start + i ];
+        String expectedLine = expectedLines[ i ];
+        if ( !line.equals( expectedLine ) )
+        {
+            throw new IllegalArgumentException( "unexpected line for " + fileName + ":\n  expected: " + expectedLine + "\n  actual: " + line );
+        }
+    }
+}
+
+boolean result = true;
+try
+{
+    assertLines( "ClassWithJavadoc.java", 21, new String[] {
+        "/**",
+        " * Some Javadoc.",
+        " *",
+        " * @version 1.2.3",  // should have added version
+        " */",
+    } );
+    // Should not have added `@version` to nested class
+    assertLines( "ClassWithJavadoc.java", 28, new String[] {
+        "    /**",
+        "     * Nested",
+        "     */",
+    } );
+
+
+    assertLines( "ClassWithJavadocAndVersion.java", 21, new String[] {
+        "/**",
+        " * Some Javadoc.",
+        " *",
+        " * @version 5.6.7",  // should have kept existing version
+        " */",
+    } );
+
+
+    assertLines( "ClassWithNoJavadoc.java", 21, new String[] {
+        "/**",
+        " * <p>ClassWithNoJavadoc class.</p>",
+        " *",
+        " * @version 1.2.3",  // should have added version
+        " */",
+    } );
+    // Did not add Javadoc to nested class (TODO: missing javadoc:fix functionality?; but should not add `@version`)
+    assertLines( "ClassWithNoJavadoc.java", 27, new String[] {
+        "{",
+        "    public static class NestedClass",
+    } );
+}
+catch( Throwable e )
+{
+    e.printStackTrace();
+    result = false;
+}
+
+return result;


### PR DESCRIPTION
See https://github.com/apache/maven-javadoc-plugin/pull/295#issuecomment-2227104630; currently there is no test for a custom `FixJavadocMojo#defaultVersion` value.

I am not that familiar with the Invoker Plugin and the test setup here, so please let me know if I should change anything. I also tried to match the existing Java code formatting style.

----

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJAVADOC) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue.  Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify -Prun-its` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

