### PR TITLE
[MJAVADOC-810] [REGRESSION] MJAVADOC-791 causes forked Maven execution fail if any toolchains or settings file isn't present

### DIFF
--- a/src/it/projects/MJAVADOC-257/mymojo/pom.xml
+++ b/src/it/projects/MJAVADOC-257/mymojo/pom.xml
@@ -44,4 +44,16 @@
       <version>@mavenVersion@</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <configuration>
+          <goalPrefix>mjavadoc-257</goalPrefix>
+        </configuration>
+        </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
@@ -780,10 +780,18 @@ public class JavadocUtil {
         InvocationRequest request = new DefaultInvocationRequest();
         request.setBaseDirectory(projectFile.getParentFile());
         request.setPomFile(projectFile);
-        request.setGlobalSettingsFile(globalSettingsFile);
-        request.setUserSettingsFile(userSettingsFile);
-        request.setGlobalToolchainsFile(globalToolchainsFile);
-        request.setToolchainsFile(userToolchainsFile);
+        if (globalSettingsFile != null && globalSettingsFile.isFile()) {
+            request.setGlobalSettingsFile(globalSettingsFile);
+        }
+        if (userSettingsFile != null && userSettingsFile.isFile()) {
+            request.setUserSettingsFile(userSettingsFile);
+        }
+        if (globalToolchainsFile != null && globalToolchainsFile.isFile()) {
+            request.setGlobalToolchainsFile(globalToolchainsFile);
+        }
+        if (userToolchainsFile != null && userToolchainsFile.isFile()) {
+            request.setToolchainsFile(userToolchainsFile);
+        }
         request.setBatchMode(true);
         if (log != null) {
             request.setDebug(log.isDebugEnabled());


### PR DESCRIPTION
As request carries the "effective" value (default or user overriden ones) but it does not mean they exist. And as invoker used, effect is same as user would use -s/-t CLI commands with non-existent files: mvn CLI failure.
