### PR TITLE
refactor: Replace Plexus AbstractLogEnabled with SLF4J

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,6 +286,12 @@ under the License.
       <version>2.1.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4jVersion}</version>
+    </dependency>
+
     <!-- Plexus -->
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -401,12 +407,6 @@ under the License.
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>3.26.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4jVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/apache/maven/plugins/javadoc/resolver/ResourceResolver.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/resolver/ResourceResolver.java
@@ -54,7 +54,6 @@ import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
@@ -62,13 +61,16 @@ import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.DependencyFilter;
 import org.eclipse.aether.resolution.ArtifactRequest;
 import org.eclipse.aether.resolution.ArtifactResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  */
 @Named
 @Singleton
-public final class ResourceResolver extends AbstractLogEnabled {
+public final class ResourceResolver {
+    private static final Logger logger = LoggerFactory.getLogger(ResourceResolver.class);
     @Inject
     private RepositorySystem repoSystem;
 
@@ -220,8 +222,8 @@ public final class ResourceResolver extends AbstractLogEnabled {
         try {
             dirs = resolveAndUnpack(toResolve, config, RESOURCE_VALID_CLASSIFIERS, false);
         } catch (ArtifactResolutionException | ArtifactNotFoundException e) {
-            if (getLogger().isDebugEnabled()) {
-                getLogger().debug(e.getMessage(), e);
+            if (logger.isDebugEnabled()) {
+                logger.debug(e.getMessage(), e);
             }
         }
 

--- a/src/main/java/org/apache/maven/plugins/javadoc/resolver/ResourceResolver.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/resolver/ResourceResolver.java
@@ -70,7 +70,8 @@ import org.slf4j.LoggerFactory;
 @Named
 @Singleton
 public final class ResourceResolver {
-    private static final Logger logger = LoggerFactory.getLogger(ResourceResolver.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceResolver.class);
+
     @Inject
     private RepositorySystem repoSystem;
 
@@ -222,8 +223,8 @@ public final class ResourceResolver {
         try {
             dirs = resolveAndUnpack(toResolve, config, RESOURCE_VALID_CLASSIFIERS, false);
         } catch (ArtifactResolutionException | ArtifactNotFoundException e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug(e.getMessage(), e);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(e.getMessage(), e);
             }
         }
 


### PR DESCRIPTION
As seen on https://cwiki.apache.org/confluence/plugins/servlet/mobile?contentId=181305684#MavenEcosystemCleanup-DropPlexusContainerforJSR-330+SisuGuiceextension

- Leverages https://github.com/openrewrite/rewrite-apache/pull/41

I have another two lined up for apache/maven and apache/maven-archetype that I'll verify first.

@elharo if you wouldn't mind, could you look this over?

Use this link to re-run the recipe: https://app.moderne.io/builder/P4zH7djn6?organizationId=QXBhY2hlIE1hdmVu