### PR TITLE
[MJAVADOC-823] legacyMode keeps using module-info.java (-sourcedirectory still use as well as java files input)

### DIFF
--- a/src/it/projects/MJAVADOC-823/b/c/d1/pom.xml
+++ b/src/it/projects/MJAVADOC-823/b/c/d1/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.javadoc.it</groupId>
+    <artifactId>mjavadoc823c</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>mjavadoc823d1</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.16</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/projects/MJAVADOC-823/b/c/d1/src/main/java/a/b/c/d/D1.java
+++ b/src/it/projects/MJAVADOC-823/b/c/d1/src/main/java/a/b/c/d/D1.java
@@ -1,0 +1,25 @@
+package a.b.c.d;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class D1
+{
+
+}

--- a/src/it/projects/MJAVADOC-823/b/c/d1/src/main/java/module-info.java
+++ b/src/it/projects/MJAVADOC-823/b/c/d1/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module a.b.c.d.d {
+    exports a.b.c.d;
+    requires org.slf4j;
+}

--- a/src/it/projects/MJAVADOC-823/b/c/d2/pom.xml
+++ b/src/it/projects/MJAVADOC-823/b/c/d2/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.javadoc.it</groupId>
+    <artifactId>mjavadoc823c</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>mjavadoc13d2</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.plugins.javadoc.it</groupId>
+      <artifactId>mjavadoc823d1</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/projects/MJAVADOC-823/b/c/d2/src/main/java/a/b/c/d/D2.java
+++ b/src/it/projects/MJAVADOC-823/b/c/d2/src/main/java/a/b/c/d/D2.java
@@ -1,0 +1,28 @@
+package a.b.c.d;
+
+import a.b.c.d.D1;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class D2
+{
+    private D1 d1;
+
+}

--- a/src/it/projects/MJAVADOC-823/b/c/pom.xml
+++ b/src/it/projects/MJAVADOC-823/b/c/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.javadoc.it</groupId>
+    <artifactId>mjavadoc823b</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>mjavadoc823c</artifactId>
+  <packaging>pom</packaging>
+  
+  <modules>
+    <module>d1</module>
+    <module>d2</module>
+  </modules>
+
+</project>

--- a/src/it/projects/MJAVADOC-823/b/e/pom.xml
+++ b/src/it/projects/MJAVADOC-823/b/e/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.javadoc.it</groupId>
+    <artifactId>mjavadoc823b</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>mjavadoc823e</artifactId>
+
+</project>

--- a/src/it/projects/MJAVADOC-823/b/e/src/main/java/a/b/e/E.java
+++ b/src/it/projects/MJAVADOC-823/b/e/src/main/java/a/b/e/E.java
@@ -1,0 +1,25 @@
+package a.b.e;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public interface E
+{
+    
+}

--- a/src/it/projects/MJAVADOC-823/b/pom.xml
+++ b/src/it/projects/MJAVADOC-823/b/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.javadoc.it</groupId>
+    <artifactId>mjavadoc823</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>mjavadoc823b</artifactId>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>c</module>
+    <module>e</module>
+  </modules>
+
+</project>

--- a/src/it/projects/MJAVADOC-823/f/pom.xml
+++ b/src/it/projects/MJAVADOC-823/f/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.javadoc.it</groupId>
+    <artifactId>mjavadoc823</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>mjavadoc13df</artifactId>
+
+</project>

--- a/src/it/projects/MJAVADOC-823/f/src/main/java/a/f/F.java
+++ b/src/it/projects/MJAVADOC-823/f/src/main/java/a/f/F.java
@@ -1,0 +1,24 @@
+package a.f;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public interface F
+{
+}

--- a/src/it/projects/MJAVADOC-823/invoker.properties
+++ b/src/it/projects/MJAVADOC-823/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.java.version = 11+
+invoker.goals = javadoc:aggregate

--- a/src/it/projects/MJAVADOC-823/pom.xml
+++ b/src/it/projects/MJAVADOC-823/pom.xml
@@ -32,8 +32,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <modules>
@@ -44,6 +43,11 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.13.0</version>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>

--- a/src/it/projects/MJAVADOC-823/pom.xml
+++ b/src/it/projects/MJAVADOC-823/pom.xml
@@ -58,7 +58,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>@project.version@</version>
           <configuration>
-            <disableSourcepathEmpty>true</disableSourcepathEmpty>
+            <disableSourcepathUsage>true</disableSourcepathUsage>
             <legacyMode>true</legacyMode>
             <sourceFileExcludes>
               <sourceFileExclude>**/module-info.java</sourceFileExclude>

--- a/src/it/projects/MJAVADOC-823/pom.xml
+++ b/src/it/projects/MJAVADOC-823/pom.xml
@@ -32,7 +32,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <modules>

--- a/src/it/projects/MJAVADOC-823/pom.xml
+++ b/src/it/projects/MJAVADOC-823/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.javadoc.it</groupId>
+  <artifactId>mjavadoc823</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <url>https://issues.apache.org/jira/browse/MJAVADOC-823</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
+
+  <modules>
+    <module>b</module>
+    <module>f</module>
+  </modules>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>@sitePluginVersion@</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>@project.version@</version>
+          <configuration>
+            <disableSourcepathEmpty>true</disableSourcepathEmpty>
+            <legacyMode>true</legacyMode>
+            <sourceFileExcludes>
+              <sourceFileExclude>**/module-info.java</sourceFileExclude>
+            </sourceFileExcludes>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/it/projects/MJAVADOC-823/verify.groovy
+++ b/src/it/projects/MJAVADOC-823/verify.groovy
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Aggregate
+assert new File( basedir, 'target/reports/apidocs/a/b/c/d/D1.html').exists()
+assert new File( basedir, 'target/reports/apidocs/a/b/c/d/D2.html').exists()
+assert new File( basedir, 'target/reports/apidocs/a/b/e/E.html').exists()
+assert new File( basedir, 'target/reports/apidocs/a/f/F.html').exists()
+

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -841,14 +841,16 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
      * The javadoc need to be called with empty {@code -sourcepath} argument and files are in the argfile
      * This usually need to be used with the following configuration
      * <pre>
+     * {@code
      *   <sourceFileExcludes>
      *     <sourceFileExclude>**\/module-info.java</sourceFileExclude>
      *   </sourceFileExcludes>
+     * }
      * </pre>
      * @since 3.11.2
      */
-    @Parameter(property = "maven.javadoc.disableSourcepathEmpty")
-    private boolean disableSourcepathEmpty;
+    @Parameter(property = "maven.javadoc.disableSourcepathUsage")
+    private boolean disableSourcepathUsage;
 
     /**
      * Specifies the package directory where javadoc will be executed. Multiple packages can be separated by
@@ -4643,7 +4645,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
         }
 
         if (moduleSourceDir == null) {
-            if (!disableSourcepathEmpty) {
+            if (!disableSourcepathUsage) {
                 addArgIfNotEmpty(
                         arguments,
                         "-sourcepath",

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -837,6 +837,20 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
     private String sourcepath;
 
     /**
+     * When using legacyMode and aggregated javadoc, users may have a mix of Maven modules with module files and not.
+     * The javadoc need to be called with empty {@code -sourcepath} argument and files are in the argfile
+     * This usually need to be used with the following configuration
+     * <pre>
+     *   <sourceFileExcludes>
+     *     <sourceFileExclude>**\/module-info.java</sourceFileExclude>
+     *   </sourceFileExcludes>
+     * </pre>
+     * @since 3.11.2
+     */
+    @Parameter(property = "maven.javadoc.disableSourcepathEmpty")
+    private boolean disableSourcepathEmpty;
+
+    /**
      * Specifies the package directory where javadoc will be executed. Multiple packages can be separated by
      * colons (<code>:</code>).
      * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/man/javadoc.html#options-for-javadoc">Javadoc option subpackages</a>.
@@ -4629,8 +4643,15 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
         }
 
         if (moduleSourceDir == null) {
-            addArgIfNotEmpty(
-                    arguments, "-sourcepath", JavadocUtil.quotedPathArgument(getSourcePath(sourcePaths)), false, false);
+            if (!disableSourcepathEmpty) {
+                addArgIfNotEmpty(
+                        arguments,
+                        "-sourcepath",
+                        JavadocUtil.quotedPathArgument(getSourcePath(sourcePaths)),
+                        false,
+                        false);
+            }
+
         } else if (mainResolvePathResult == null
                 || ModuleNameSource.MODULEDESCRIPTOR.equals(mainResolvePathResult.getModuleNameSource())) {
             addArgIfNotEmpty(
@@ -4646,7 +4667,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
 
         addArgIf(arguments, verbose, "-verbose");
 
-        if (additionalOptions != null && additionalOptions.length > 0) {
+        if (additionalOptions != null) {
             for (String additionalOption : additionalOptions) {
                 arguments.add(additionalOption.replaceAll("(?<!\\\\)\\\\(?!\\\\|:)", "\\\\"));
             }

--- a/src/main/java/org/apache/maven/plugins/javadoc/JavadocReport.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/JavadocReport.java
@@ -209,11 +209,7 @@ public class JavadocReport extends AbstractJavadocMojo implements MavenMultiPage
 
         Map<Path, Collection<String>> files = getFiles(collectedSourcePaths);
 
-        if (!canGenerateReport(files)) {
-            return false;
-        }
-
-        return true;
+        return canGenerateReport(files);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MJAVADOC) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue.  Your pull request should address just this issue, without
       pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[MJAVADOC-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MJAVADOC-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the
       commit message.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify -Prun-its` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [ ] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

