### PR TITLE
(doc) Close links tag in links parameter javadoc example

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -1072,7 +1072,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
      * <pre>
      * &lt;links&gt;
      *   &lt;link&gt;https://docs.oracle.com/en/java/javase/17/docs/api&lt;/link&gt;
-     * &lt;links&gt;
+     * &lt;/links&gt;
      * </pre>
      * will be used because <code>https://docs.oracle.com/en/java/javase/17/docs/api/element-list</code> exists.</li>
      * <li>If {@link #detectLinks} is defined, the links between the project dependencies are


### PR DESCRIPTION
Teeny tiny change to add a / to the end tag in an example in a javadoc for the links configuration.

 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

