### PR TITLE
Respect the SOURCE_DATE_EPOCH variable from environment for reproducible builds

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -2671,6 +2671,15 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
     private String getBottomText() {
         final String inceptionYear = project.getInceptionYear();
 
+        final String sourceDateEpoch = System.getenv("SOURCE_DATE_EPOCH");
+        if (sourceDateEpoch != null) {
+            if (outputTimestamp == null
+                    || outputTimestamp.length() < 1
+                    || ((outputTimestamp.length() == 1) && !Character.isDigit(outputTimestamp.charAt(0)))) {
+                outputTimestamp = sourceDateEpoch;
+            }
+        }
+
         // get Reproducible Builds outputTimestamp date value or the current local date.
         final LocalDate localDate = MavenArchiver.parseBuildOutputTimestamp(outputTimestamp)
                 .map(instant -> instant.atZone(ZoneOffset.UTC).toLocalDate())


### PR DESCRIPTION
If the SOURCE_DATE_EPOCH variable is not set in the environment, nothing should change. If it is set, the outputTimestemp is the first to consider, but if it is not set, or it is cancelled, in the case where the outputTimeStamp is set to SOURCE_DATE_EPOCH.
This environmental variable is basically the standard across linux distributors for reproducible builds, and it is unlikely to be set otherwise. But this is basically for me a weather balloon to check whether something like this could be accepted upstream. If not, I will continue to carry it as a patch in our builds.