### PR TITLE
Remove Javadoc 1.4+ / -1.1 switch related warning

### DIFF
--- a/src/it/projects/MJAVADOC-770/verify.groovy
+++ b/src/it/projects/MJAVADOC-770/verify.groovy
@@ -21,8 +21,3 @@
 def moduleFile = new File( basedir, 'target/reports/apidocs/mjavadoc770/module-summary.html')
 
 assert !moduleFile.exists()
-
-
-def log = new File( basedir, 'build.log').text
-
-assert log.count( "[WARNING] Javadoc 1.4+ doesn't support the -1.1 switch anymore. Ignore this option." ) == 0

--- a/src/it/projects/MJAVADOC-770/verify.groovy
+++ b/src/it/projects/MJAVADOC-770/verify.groovy
@@ -21,3 +21,8 @@
 def moduleFile = new File( basedir, 'target/reports/apidocs/mjavadoc770/module-summary.html')
 
 assert !moduleFile.exists()
+
+
+def log = new File( basedir, 'build.log').text
+
+assert log.count( "[WARNING] Javadoc 1.4+ doesn't support the -1.1 switch anymore. Ignore this option." ) == 0

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -4324,10 +4324,6 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
 
         // all options in alphabetical order
 
-        if (old && getLog().isWarnEnabled()) {
-            getLog().warn("Javadoc 1.4+ doesn't support the -1.1 switch anymore. Ignore this option.");
-        }
-
         addArgIfNotEmpty(arguments, "-bootclasspath", JavadocUtil.quotedPathArgument(getBootclassPath()));
 
         if (breakiterator) {

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -733,6 +733,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
      * Javadoc 1.1. This is no longer supported since Javadoc 1.4 (shipped with JDK 1.4)
      *
      * @see <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#a1.1">Javadoc option 1.1</a>.
+     * @deprecated No longer used.
      */
     @Parameter(property = "old", defaultValue = "false")
     @Deprecated

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -4324,7 +4324,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
 
         // all options in alphabetical order
 
-        if (getLog().isWarnEnabled()) {
+        if (old && getLog().isWarnEnabled()) {
             getLog().warn("Javadoc 1.4+ doesn't support the -1.1 switch anymore. Ignore this option.");
         }
 


### PR DESCRIPTION
This commit reverts the behavior introduced in d3fbbda8cf67fafd69ffe54ec0170e5aeb9e1166, after which a warning about the `-1.1` switch appears unconditionally. The warning, "Javadoc 1.4+ doesn't support the -1.1 switch anymore. Ignore this option." now only displays if the `old` parameter is set to true, as it did previously.

---

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

