### PR TITLE
Fix `package {...} does not exist` in `legacyMode`

### DIFF
--- a/src/it/projects/GITHUB-1242/invoker.properties
+++ b/src/it/projects/GITHUB-1242/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=package javadoc:aggregate

--- a/src/it/projects/GITHUB-1242/pom.xml
+++ b/src/it/projects/GITHUB-1242/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.javadoc.it</groupId>
+    <artifactId>GITHUB-1242</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <url>https://github.com/apache/maven-javadoc-plugin/issues/1242</url>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <legacyMode>true</legacyMode>
+                    <excludePackageNames>*.impl</excludePackageNames>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/projects/GITHUB-1242/pom.xml
+++ b/src/it/projects/GITHUB-1242/pom.xml
@@ -22,8 +22,19 @@
 
     <url>https://github.com/apache/maven-javadoc-plugin/issues/1242</url>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>@maven.compiler.source@</maven.compiler.source>
+        <maven.compiler.target>@maven.compiler.target@</maven.compiler.target>
+    </properties>
+
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>@compilerPluginVersion@</version>
+            </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>@project.version@</version>

--- a/src/it/projects/GITHUB-1242/src/main/java/com/fruit/Fruits.java
+++ b/src/it/projects/GITHUB-1242/src/main/java/com/fruit/Fruits.java
@@ -1,0 +1,24 @@
+package com.fruit;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public final class Fruits {
+    private com.fruit.impl.Apple apple;
+}

--- a/src/it/projects/GITHUB-1242/src/main/java/com/fruit/impl/Apple.java
+++ b/src/it/projects/GITHUB-1242/src/main/java/com/fruit/impl/Apple.java
@@ -1,0 +1,23 @@
+package com.fruit.impl;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public final class Apple {
+}

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -4606,7 +4606,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
         }
 
         if (moduleSourceDir == null) {
-            if (!disableSourcepathUsage && !legacyMode) {
+            if (!disableSourcepathUsage) {
                 addArgIfNotEmpty(
                         arguments,
                         "-sourcepath",


### PR DESCRIPTION
_Partially_ reverts change in https://github.com/apache/maven-javadoc-plugin/pull/1217, specifically:
> Do not use --source-path in legacy mode as not to suck any of those module-info.java files back

This is required to ensure correct package resolution on projects that mix modular & non-module Java code.

Fixes: https://github.com/apache/maven-javadoc-plugin/issues/1242

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
