### PR TITLE
Ensure UTF-8 charset is used to avoid IllegalArgumentException: Null charset name

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -5394,8 +5394,8 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
                     logError("MavenInvocationException: " + e.getMessage(), e);
 
                     try {
-                        String invokerLogContent = new String(Files.readAllBytes(invokerLogFile.toPath()),
-                            StandardCharsets.UTF_8);
+                        String invokerLogContent =
+                                new String(Files.readAllBytes(invokerLogFile.toPath()), StandardCharsets.UTF_8);
                         // TODO: Why are we only interested in cases where the JVM won't start?
                         // probably we should throw an error in all cases
                         // [MJAVADOC-275][jdcasey] I changed the logic here to only throw an error WHEN
@@ -5403,8 +5403,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
                         if (invokerLogContent.contains(JavadocUtil.ERROR_INIT_VM)) {
                             throw new MavenReportException(e.getMessage(), e);
                         }
-                    }
-                    catch (IOException ex) {
+                    } catch (IOException ex) {
                         // ignore
                     }
                 } finally {

--- a/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/JavadocUtil.java
@@ -827,12 +827,11 @@ public class JavadocUtil {
 
         if (result.getExitCode() != 0) {
             try {
-                String invokerLogContent = new String(Files.readAllBytes(invokerLog.toPath()),
-                    StandardCharsets.UTF_8);
+                String invokerLogContent = new String(Files.readAllBytes(invokerLog.toPath()), StandardCharsets.UTF_8);
 
                 // see DefaultMaven
                 if (!invokerLogContent.contains("Scanning for projects...")
-                    || invokerLogContent.contains(OutOfMemoryError.class.getName())) {
+                        || invokerLogContent.contains(OutOfMemoryError.class.getName())) {
                     if (log != null) {
                         log.error("Error occurred during initialization of VM, trying to use an empty MAVEN_OPTS...");
 
@@ -842,19 +841,18 @@ public class JavadocUtil {
                     }
                 }
             } catch (IOException e) {
-              // ignore
+                // ignore
             }
             result = invoke(log, invoker, request, invokerLog, goals, properties, "");
         }
 
         if (result.getExitCode() != 0) {
             try {
-                String invokerLogContent = new String(Files.readAllBytes(invokerLog.toPath()),
-                    StandardCharsets.UTF_8);
+                String invokerLogContent = new String(Files.readAllBytes(invokerLog.toPath()), StandardCharsets.UTF_8);
 
                 // see DefaultMaven
                 if (!invokerLogContent.contains("Scanning for projects...")
-                                || invokerLogContent.contains(OutOfMemoryError.class.getName())) {
+                        || invokerLogContent.contains(OutOfMemoryError.class.getName())) {
                     throw new MavenInvocationException(ERROR_INIT_VM);
                 }
 


### PR DESCRIPTION
@wendigo fixes #1241


On inspection I realized that the existing code is working at cross-purposes to the design of Java in that it catches an exception and  converts it to null. That is, it converts an exception to an error flag that has to be explicitly checked for. Instead the exception should be caught and handled. I deprecated the method and replaced all usages within this plugin. Since the method is protected inside what should be (but isn't) a static utility class, I doubt anyone else is subclassing and invoking this, but just in case I left it in. 