### PR TITLE
Fix legacyMode 

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -4603,7 +4603,8 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
         }
 
         if (moduleSourceDir == null) {
-            if (!disableSourcepathUsage) {
+            if (!disableSourcepathUsage
+                    && (!legacyMode || (excludePackageNames != null && !excludePackageNames.isEmpty()))) {
                 addArgIfNotEmpty(
                         arguments,
                         "-sourcepath",


### PR DESCRIPTION
There is no way to exclude module-info.java by package name. That is why when one is in legacyMode, one enters the file-based mode in order to be able to exclude them. Adding -sourcepath in this case simply causes the javadoc to consider the module-info.java files again. With the javadoc:aggregate goal, this ends up in error.
This PR intents to cater for the problem in #1243 but still keep the #1217 intention intact. When in legacyMode and the excludePackageNames is specified, we have no choice but to add the -sourcepath. Because in the file-based mode, the files corresponding to the excluded package names will not be listed and might cause unresolved symbols. But in all other cases, the -sourcepath should not be needed.
All the integration tests are passing with this change, even the one that was introduced by #1243 . I verified that the generated javadoc and the `javadoc.sh`, `argfile` and `option` files are identical in both cases.