### PR TITLE
Fix MalformedInputException on Windows with Java 8 due to charset mis…

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/StaleHelper.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/StaleHelper.java
@@ -20,6 +20,8 @@ package org.apache.maven.plugins.javadoc;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -56,8 +58,12 @@ public class StaleHelper {
             for (String arg : args) {
                 if (arg.startsWith("@")) {
                     String name = arg.substring(1);
-                    options.addAll(Files.readAllLines(dir.resolve(name), UTF_8));
                     ignored.add(name);
+                    try {
+                        options.addAll(Files.readAllLines(dir.resolve(name), UTF_8));
+                    } catch (CharacterCodingException e) {
+                        options.addAll(Files.readAllLines(dir.resolve(name), Charset.defaultCharset()));
+                    }
                 }
             }
             List<String> state = new ArrayList<>(options);


### PR DESCRIPTION
…match in stale data cache

## Problem

Starting in version 3.11.3, running `mvn javadoc:javadoc` twice in succession on Windows with Java 8 fails on the second run with:

```
java.nio.charset.MalformedInputException: Input length = 1
    at org.apache.maven.plugins.javadoc.AbstractJavadocMojo.isUpToDate(AbstractJavadocMojo.java:5008)
```

This regression affects Windows users running Java 8, where the default platform encoding is `Cp1252`.

## Root Cause

The issue stems from a charset mismatch in how the stale data cache file is written versus how it's read:

1. **Write operation** (`StaleHelper.writeStaleData()`, line 126):
   - Uses `getDataCharset()` which returns `Charset.defaultCharset()` for Java 8
   - On Windows, this is `Cp1252`

2. **Read operation** (`AbstractJavadocMojo.isUpToDate()`, line 5008):
   - Always uses hardcoded `StandardCharsets.UTF_8`

When the second run attempts to read a file written with `Cp1252` encoding using `UTF-8`, any non-ASCII bytes cause a `MalformedInputException`.

## Solution

Changed `StaleHelper` to always save in `StandardCharsets.UTF_8` instead of platform-dependent charset. This ensures:
- Consistent encoding across all platforms (Windows, macOS, Linux)
- Consistent encoding across all Java versions (8, 11, 17, 21, etc.)
- Write and read operations use the same charset

Fixes: #1273 #1264
