### PR TITLE
Remove links for fix-javadoc and change-output examples

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -43,15 +43,13 @@ under the License.
       <item name="Using Alternate Doclets" href="/examples/alternate-doclet.html"/>
       <item name="Using Alternate Javadoc Tool" href="/examples/alternate-javadoc-tool.html"/>
       <item name="Using Javadoc Resources" href="/examples/javadoc-resources.html"/>
-      <item name="Using Alternative Output Directory" href="/examples/output-configuration.html"/>
       <item name="Configuring Stylesheets" href="/examples/stylesheet-configuration.html"/>
       <item name="Configuring Helpfile" href="/examples/help-configuration.html"/>
       <item name="Configuring Custom Tags" href="/examples/tag-configuration.html"/>
       <item name="Configuring Custom Taglets" href="/examples/taglet-configuration.html"/>
       <item name="Configuring links" href="/examples/links-configuration.html"/>
       <item name="Generating Test Javadocs" href="/examples/test-javadocs.html"/>
-      <item name="Selective Javadocs Reports" href="/examples/selective-javadocs-report.html"/>
-      <item name="Fixing Javadoc Comments" href="/examples/fix-javadocs.html"/>
+      <item name="Selective Javadocs Reports" href="/examples/selective-javadocs-report.html"/>      
       <item name="Adding additional dependencies" href="/examples/additional-dependencies.html"/>
       <item name="Generate Javadoc without duplicate execution of phase generate-sources" href="/examples/javadoc-nofork.html"/>
       <item name="Generate aggregate Javadoc without duplicate execution of phase compile" href="/examples/aggregate-nofork.html"/>


### PR DESCRIPTION
Output example was removed by #349 (Dec 2024)
Fix-Javadoc was removed by #1263 (Sep 2025)

fixes https://github.com/apache/maven-site/issues/1450
fixes https://github.com/apache/maven-site/issues/1449