### PR TITLE
fix: Use actually Javadoc version to determine capabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,9 @@ under the License.
     <contributor>
       <name>Julian Reschke</name>
     </contributor>
+    <contributor>
+      <name>Niels Basjes</name>
+    </contributor>
   </contributors>
 
   <prerequisites>
@@ -126,6 +129,7 @@ under the License.
     <pluginPluginVersion>${version.maven-plugin-tools}</pluginPluginVersion>
     <jarPluginVersion>${version.maven-jar-plugin}</jarPluginVersion>
     <sitePluginVersion>${version.maven-site-plugin}</sitePluginVersion>
+    <toolchainPluginVersion>3.2.0</toolchainPluginVersion>
     <projectInfoReportsPluginVersion>${version.maven-project-info-reports-plugin}</projectInfoReportsPluginVersion>
     <project.build.outputTimestamp>2025-09-16T08:27:46Z</project.build.outputTimestamp>
     <slf4jVersion>1.7.36</slf4jVersion>

--- a/src/it/projects/GITHUB-1244-ToolChains/invoker.properties
+++ b/src/it/projects/GITHUB-1244-ToolChains/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This verifies that Java 21 LTS is used instead of the Java 25 LTS used by Maven.
+invoker.java.version = 25
+invoker.toolchain.jdk.version = [21,22)

--- a/src/it/projects/GITHUB-1244-ToolChains/pom.xml
+++ b/src/it/projects/GITHUB-1244-ToolChains/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.javadoc.it</groupId>
+  <artifactId>github-1244-toolchains</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <url>https://github.com/apache/maven-javadoc-plugin/issues/1244</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-toolchains-plugin</artifactId>
+        <version>@toolchainPluginVersion@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>select-jdk-toolchain</goal>
+            </goals>
+            <configuration>
+              <version>[21,22)</version>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@compilerPluginVersion@</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/projects/GITHUB-1244-ToolChains/src/main/java/nl/basjes/Dummy.java
+++ b/src/it/projects/GITHUB-1244-ToolChains/src/main/java/nl/basjes/Dummy.java
@@ -1,0 +1,27 @@
+package nl.basjes;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A dummy class
+ */
+public class Dummy {
+
+}

--- a/src/it/projects/MJAVADOC-704_toolchains/invoker.properties
+++ b/src/it/projects/MJAVADOC-704_toolchains/invoker.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.toolchain.jdk.version = 11
+invoker.toolchain.jdk.version = [11,12)

--- a/src/it/projects/MJAVADOC-787/invoker.properties
+++ b/src/it/projects/MJAVADOC-787/invoker.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.toolchain.jdk.version = 1.8
+invoker.toolchain.jdk.version = [8,9)

--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -1991,7 +1991,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
         // ----------------------------------------------------------------------
         List<String> javadocArguments = new ArrayList<>();
 
-        if (JavaVersion.JAVA_VERSION.isAtLeast("23") && !disableNoFonts) {
+        if (javadocRuntimeVersion.isAtLeast("23") && !disableNoFonts) {
             javadocArguments.add("--no-fonts");
         }
 
@@ -2741,7 +2741,7 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
         if (new File(stylesheetfile).exists()) {
             return Optional.of(new File(stylesheetfile));
         }
-        if (JavaVersion.JAVA_VERSION.isAtLeast("23")) {
+        if (javadocRuntimeVersion.isAtLeast("23")) {
             return getResource(
                     new File(new File(javadocOutputDirectory, "resource-files"), DEFAULT_CSS_NAME), stylesheetfile);
         }


### PR DESCRIPTION
This is my proposed fix for https://github.com/apache/maven-javadoc-plugin/issues/1244
The change was simple: instead of looking at the Java version, look at the javadoc version.

Following this checklist to help us incorporate your contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf). I'm a committer/pmc for Avro and a committer for Flink.
