### PR TITLE
docletPath with relative path resolves incorrectly causing AssertionE…

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -2892,7 +2892,9 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
         }
 
         if (!(docletPath == null || docletPath.isEmpty())) {
-            pathParts.add(JavadocUtil.unifyPathSeparator(docletPath));
+            for (Path path : JavadocUtil.prunePaths(project, Arrays.asList(JavadocUtil.splitPath(docletPath)), true)) {
+                pathParts.add(path.toString());
+            }
         }
 
         String path = StringUtils.join(pathParts.iterator(), File.pathSeparator);

--- a/src/test/java/org/apache/maven/plugins/javadoc/JavadocUtilTest.java
+++ b/src/test/java/org/apache/maven/plugins/javadoc/JavadocUtilTest.java
@@ -628,6 +628,22 @@ class JavadocUtilTest {
         assertEquals(expectedWithJar, JavadocUtil.prunePaths(project, list, true));
     }
 
+    @Test
+    void testPrunePathsResolvesRelativePaths() {
+        // Regression test for MJAVADOC-812:
+        // docletPath with a relative path (e.g. "target/classes") was written verbatim to the
+        // javadoc options file. The javadoc tool runs from target/reports/testapidocs, so the
+        // relative path resolved to the wrong location, causing the wrong class to be loaded
+        // and triggering: AssertionError: ignored flag: -Xlint:-options on Java 25.
+        MavenProjectStub project = new MavenProjectStub();
+        project.setFile(new File(getBasedir(), "pom.xml"));
+
+        Collection<Path> result = JavadocUtil.prunePaths(project, Collections.singletonList("target/classes"), false);
+
+        assertFalse(result.isEmpty(), "relative docletPath should resolve to an existing directory");
+        result.forEach(p -> assertTrue(p.isAbsolute(), "resolved path must be absolute, was: " + p));
+    }
+
     /**
      * Method to test unifyPathSeparator()
      */


### PR DESCRIPTION

<docletPath> with a relative path is written verbatim to the javadoc options file. The javadoc tool runs from target/reports/testapidocs, so a relative path like target/test-classes resolves to 
target/reports/testapidocs/target/test-classes — which doesn't exist. This causes the wrong class to be loaded from the classpath, which on Java 25 triggers a fatal assertion error:

error: fatal error encountered: java.lang.AssertionError: ignored flag: -Xlint:-options


On Java 21 and earlier the wrong class was silently loaded without crashing.

Fix: In AbstractJavadocMojo.getDocletPath(), resolve docletPath entries through JavadocUtil.prunePaths() (which resolves relative paths against project.getBasedir()) instead of passing them verbatim via 
unifyPathSeparator(). This is consistent with how other path parameters are already handled.

Note: testJavadocResourcesWithExcludes fails on a second consecutive mvn verify without clean due to a pre-existing stale data/test isolation issue in the suite — unrelated to this fix. mvn clean verify passes.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

Checklist status:
- ✅ Addresses one issue only
- ✅ Unit test added: JavadocUtilTest.testPrunePathsResolvesRelativePaths() — fails without the fix, passes with it
- ✅ mvn clean verify passes
- ⚠️ Integration tests (mvn -Prun-its verify) — please indicate if you've run these
- ✅ ~10 lines of code change — no ICLA required
- ✅ Licensed under Apache License 2.0

