### PR TITLE
Bugfix/add runtime dependencies to test javadoc classpath

### DIFF
--- a/src/it/projects/GITHUB-1314/compile-against-runtime-in-test/pom.xml
+++ b/src/it/projects/GITHUB-1314/compile-against-runtime-in-test/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.maven.plugins.javadoc.it</groupId>
+        <artifactId>GITHUB-1314</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>compile-against-runtime-in-test</artifactId>
+    <packaging>jar</packaging>
+
+    <url>https://github.com/apache/maven-javadoc-plugin/issues/1314</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/it/projects/GITHUB-1314/compile-against-runtime-in-test/src/test/java/CompileAgainstRuntime.java
+++ b/src/it/projects/GITHUB-1314/compile-against-runtime-in-test/src/test/java/CompileAgainstRuntime.java
@@ -1,0 +1,36 @@
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+public class CompileAgainstRuntime {
+
+    /**
+     * Returns an org.slf4j.Logger.
+     * The corresponding dependency is in the "runtime" scope.
+     * This means it is only avaiable in runtime in src/main/java, but can be compiled against in src/test/java.
+     *
+     * @return A logger for the Example-class.
+     */
+    public Logger returnsRuntimeClass() {
+        return LoggerFactory.getLogger(CompileAgainstRuntime.class);
+    }
+}

--- a/src/it/projects/GITHUB-1314/invoker.properties
+++ b/src/it/projects/GITHUB-1314/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=package javadoc:test-aggregate

--- a/src/it/projects/GITHUB-1314/pom.xml
+++ b/src/it/projects/GITHUB-1314/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.plugins.javadoc.it</groupId>
+    <artifactId>GITHUB-1314</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <url>https://github.com/apache/maven-javadoc-plugin/issues/1314</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>compile-against-runtime-in-test</module>
+    </modules>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>@project.version@</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/org/apache/maven/plugins/javadoc/TestJavadocJarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/TestJavadocJarMojo.java
@@ -210,7 +210,11 @@ public class TestJavadocJarMojo extends JavadocJarMojo {
     protected ScopeDependencyFilter getDependencyScopeFilter() {
         return new ScopeDependencyFilter(
                 Arrays.asList(
-                        Artifact.SCOPE_COMPILE, Artifact.SCOPE_PROVIDED, Artifact.SCOPE_SYSTEM, Artifact.SCOPE_TEST),
+                        Artifact.SCOPE_COMPILE,
+                        Artifact.SCOPE_PROVIDED,
+                        Artifact.SCOPE_SYSTEM,
+                        Artifact.SCOPE_TEST,
+                        Artifact.SCOPE_RUNTIME),
                 null);
     }
 

--- a/src/main/java/org/apache/maven/plugins/javadoc/TestJavadocReport.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/TestJavadocReport.java
@@ -247,7 +247,11 @@ public class TestJavadocReport extends JavadocReport {
     protected ScopeDependencyFilter getDependencyScopeFilter() {
         return new ScopeDependencyFilter(
                 Arrays.asList(
-                        Artifact.SCOPE_COMPILE, Artifact.SCOPE_PROVIDED, Artifact.SCOPE_SYSTEM, Artifact.SCOPE_TEST),
+                        Artifact.SCOPE_COMPILE,
+                        Artifact.SCOPE_PROVIDED,
+                        Artifact.SCOPE_SYSTEM,
+                        Artifact.SCOPE_TEST,
+                        Artifact.SCOPE_RUNTIME),
                 null);
     }
 


### PR DESCRIPTION
This Pull Request addresses the issue I raised:
https://github.com/apache/maven-javadoc-plugin/issues/1314
The classes of any dependency within the `compile`, `runtime` or `test` scope are available to compile against in test classes. However, the maven-javadoc-plugin only used classes from `compile` and `test`. This PR fixes this behavior and adds an Integration test. 

The man code is <20 lines of code, so I assume no ICLA is needed. If it is, I'm happy to do that before the PR is performed.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
