### PR TITLE
Simply test project `pom`s - deduplicate from parent

### DIFF
--- a/src/it/projects/MJAVADOC-110/test-module/pom.xml
+++ b/src/it/projects/MJAVADOC-110/test-module/pom.xml
@@ -28,6 +28,5 @@
 
   <artifactId>test-module</artifactId>
   <packaging>jar</packaging>
-  <version>1.0-SNAPSHOT</version>
   <name>Test Module</name>
 </project>

--- a/src/it/projects/MJAVADOC-172/test-module1/pom.xml
+++ b/src/it/projects/MJAVADOC-172/test-module1/pom.xml
@@ -28,7 +28,6 @@
 
   <artifactId>test-module1</artifactId>
   <packaging>jar</packaging>
-  <version>1.0-SNAPSHOT</version>
   <name>Test Module 1</name>
   <dependencies>
     <dependency>

--- a/src/it/projects/MJAVADOC-172/test-module2/pom.xml
+++ b/src/it/projects/MJAVADOC-172/test-module2/pom.xml
@@ -28,7 +28,6 @@
 
   <artifactId>test-module2</artifactId>
   <packaging>jar</packaging>
-  <version>1.0-SNAPSHOT</version>
   <name>Test Module 2</name>
   <dependencies>
     <dependency>

--- a/src/it/projects/MJAVADOC-180/module1/pom.xml
+++ b/src/it/projects/MJAVADOC-180/module1/pom.xml
@@ -28,7 +28,6 @@
 
   <artifactId>module1</artifactId>
   <name>module1</name>
-  <version>1.0-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/src/it/projects/MJAVADOC-181/application/pom.xml
+++ b/src/it/projects/MJAVADOC-181/application/pom.xml
@@ -29,7 +29,6 @@
 
   <artifactId>application</artifactId>
   <packaging>jar</packaging>
-  <version>1.0-SNAPSHOT</version>
   <name>Application</name>
 
   <reporting>

--- a/src/it/projects/MJAVADOC-181/library/module-a/pom.xml
+++ b/src/it/projects/MJAVADOC-181/library/module-a/pom.xml
@@ -29,6 +29,5 @@
 
   <artifactId>module-a</artifactId>
   <packaging>jar</packaging>
-  <version>1.0-SNAPSHOT</version>
   <name>Module.A</name>
 </project>

--- a/src/it/projects/MJAVADOC-181/library/module-b/pom.xml
+++ b/src/it/projects/MJAVADOC-181/library/module-b/pom.xml
@@ -29,6 +29,5 @@
 
   <artifactId>module-b</artifactId>
   <packaging>jar</packaging>
-  <version>1.0-SNAPSHOT</version>
   <name>Module.B</name>
 </project>

--- a/src/it/projects/MJAVADOC-181/library/pom.xml
+++ b/src/it/projects/MJAVADOC-181/library/pom.xml
@@ -29,7 +29,6 @@
 
   <artifactId>library</artifactId>
   <packaging>pom</packaging>
-  <version>1.0-SNAPSHOT</version>
   <name>Library</name>
 
   <modules>

--- a/src/it/projects/MJAVADOC-194/module1/pom.xml
+++ b/src/it/projects/MJAVADOC-194/module1/pom.xml
@@ -28,7 +28,6 @@
   </parent>
 
   <artifactId>module1</artifactId>
-  <version>1.0.0.0-SNAPSHOT</version>
   <name>Module 1 of the Javadoc Test Project</name>
   <packaging>jar</packaging>
 

--- a/src/it/projects/MJAVADOC-194/module2/pom.xml
+++ b/src/it/projects/MJAVADOC-194/module2/pom.xml
@@ -28,7 +28,6 @@
   </parent>
 
   <artifactId>module2</artifactId>
-  <version>1.0.0.0-SNAPSHOT</version>
   <name>Module 2 of the Javadoc Test Project</name>
   <packaging>jar</packaging>
 

--- a/src/it/projects/MJAVADOC-257/mymojo/pom.xml
+++ b/src/it/projects/MJAVADOC-257/mymojo/pom.xml
@@ -32,7 +32,6 @@
   <groupId>com.mycompany.mymojo</groupId>
   <artifactId>mymojo</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>1.0-SNAPSHOT</version>
 
   <name>mymojo Maven Mojo</name>
   <url>http://maven.apache.org</url>

--- a/src/it/projects/MJAVADOC-275/mod-a/pom.xml
+++ b/src/it/projects/MJAVADOC-275/mod-a/pom.xml
@@ -29,7 +29,6 @@ under the License.
   </parent>
 
     <artifactId>MJAVADOC-275-mod-a</artifactId>
-  <version>0.1</version>
   <packaging>jar</packaging>
 
   <name>MJAVADOC - Module A</name>

--- a/src/it/projects/MJAVADOC-275/mod-b/pom.xml
+++ b/src/it/projects/MJAVADOC-275/mod-b/pom.xml
@@ -29,7 +29,6 @@ under the License.
   </parent>
 
     <artifactId>MJAVADOC-275-mod-b</artifactId>
-  <version>0.1</version>
   <packaging>jar</packaging>
 
   <name>MJAVADOC - Module B</name>

--- a/src/it/projects/MJAVADOC-275/mod-c/pom.xml
+++ b/src/it/projects/MJAVADOC-275/mod-c/pom.xml
@@ -29,7 +29,6 @@ under the License.
   </parent>
 
     <artifactId>MJAVADOC-275-mod-c</artifactId>
-  <version>0.1</version>
   <packaging>jar</packaging>
 
   <name>MJAVADOC - Module C</name>

--- a/src/it/projects/MJAVADOC-437/module1/pom.xml
+++ b/src/it/projects/MJAVADOC-437/module1/pom.xml
@@ -28,9 +28,7 @@
     <version>1.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
   <artifactId>mjavadoc437-module1</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <name>Test MJAVADOC-437 Module 1</name>
 
 </project>

--- a/src/it/projects/MJAVADOC-437/module2/pom.xml
+++ b/src/it/projects/MJAVADOC-437/module2/pom.xml
@@ -28,9 +28,7 @@
     <version>1.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
   <artifactId>mjavadoc437-module2</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <name>Test MJAVADOC-437 Module 2</name>
 
   <dependencies>

--- a/src/it/projects/MJAVADOC-497/module1/pom.xml
+++ b/src/it/projects/MJAVADOC-497/module1/pom.xml
@@ -28,9 +28,7 @@
     <version>1.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
   <artifactId>mjavadoc497-module1</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <name>Test MJAVADOC-497 Module 1</name>
 
 </project>

--- a/src/it/projects/MJAVADOC-497/module2/pom.xml
+++ b/src/it/projects/MJAVADOC-497/module2/pom.xml
@@ -28,9 +28,7 @@
     <version>1.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
   <artifactId>mjavadoc497-module2</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <name>Test MJAVADOC-497 Module 2</name>
 
 </project>

--- a/src/it/projects/MJAVADOC-618_modular-war/app/pom.xml
+++ b/src/it/projects/MJAVADOC-618_modular-war/app/pom.xml
@@ -29,7 +29,6 @@
     <version>2.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>com.mycompany</groupId>
   <artifactId>myproject</artifactId>
   <packaging>war</packaging>
   <version>1.0-SNAPSHOT</version>

--- a/src/it/projects/MJAVADOC-620_no-dot-in-version/lib/pom.xml
+++ b/src/it/projects/MJAVADOC-620_no-dot-in-version/lib/pom.xml
@@ -25,7 +25,6 @@
     <version>1.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.it</groupId>
   <artifactId>maven-MJAVADOC620-jar</artifactId>
   <version>1-SNAPSHOT</version>
 </project>

--- a/src/it/projects/MJAVADOC-682/module-1/pom.xml
+++ b/src/it/projects/MJAVADOC-682/module-1/pom.xml
@@ -29,7 +29,6 @@
     <version>1.0-SNAPSHOT</version>
   </parent>
   <artifactId>multiple-projects-same-module-name</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Module Version 1.x</name>

--- a/src/it/projects/additional-dependencies-non-aggregate/module1/pom.xml
+++ b/src/it/projects/additional-dependencies-non-aggregate/module1/pom.xml
@@ -28,7 +28,6 @@
 
   <artifactId>module1</artifactId>
   <name>module1</name>
-  <version>1.0-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/src/it/projects/additional-dependencies/module1/pom.xml
+++ b/src/it/projects/additional-dependencies/module1/pom.xml
@@ -28,7 +28,6 @@
 
   <artifactId>module1</artifactId>
   <name>module1</name>
-  <version>1.0-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/src/it/projects/detectLinks/module1/pom.xml
+++ b/src/it/projects/detectLinks/module1/pom.xml
@@ -29,6 +29,5 @@
 
   <artifactId>linkoffline-test-module1</artifactId>
   <packaging>jar</packaging>
-  <version>1.0-SNAPSHOT</version>
   <url>http://myhost/module1</url>
 </project>

--- a/src/it/projects/detectLinks/module2/pom.xml
+++ b/src/it/projects/detectLinks/module2/pom.xml
@@ -29,7 +29,6 @@
 
   <artifactId>linkoffline-test-module2</artifactId>
   <packaging>jar</packaging>
-  <version>1.0-SNAPSHOT</version>
   <url>http://myhost/module2</url>
 
   <dependencies>

--- a/src/test/resources/unit/aggregate-modules-not-in-subdirectories-test/project1/pom.xml
+++ b/src/test/resources/unit/aggregate-modules-not-in-subdirectories-test/project1/pom.xml
@@ -24,8 +24,6 @@ under the License.
     <artifactId>aggregate-modules-not-in-subdirectories-test-resources-test</artifactId>
     <version>1.0-SNAPSHOT</version>
   </parent>
-	<groupId>org.apache.maven.plugins.maven-javadoc-plugin.unit</groupId>
 	<artifactId>aggregate-modules-not-in-subdirectories-test-resources-test-project1</artifactId>
-	<version>1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 </project>

--- a/src/test/resources/unit/aggregate-modules-not-in-subdirectories-test/project2/pom.xml
+++ b/src/test/resources/unit/aggregate-modules-not-in-subdirectories-test/project2/pom.xml
@@ -25,8 +25,6 @@ under the License.
     <artifactId>aggregate-modules-not-in-subdirectories-test-resources-test</artifactId>
     <version>1.0-SNAPSHOT</version>
   </parent>
-  <groupId>org.apache.maven.plugins.maven-javadoc-plugin.unit</groupId>
   <artifactId>aggregate-modules-not-in-subdirectories-test-resources-test-project2</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 </project>

--- a/src/test/resources/unit/aggregate-resources-test/project1/pom.xml
+++ b/src/test/resources/unit/aggregate-resources-test/project1/pom.xml
@@ -26,7 +26,6 @@ under the License.
     <version>1.0-SNAPSHOT</version>
   </parent>
   <artifactId>project1</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>project1</name>
 </project>

--- a/src/test/resources/unit/aggregate-resources-test/project2/pom.xml
+++ b/src/test/resources/unit/aggregate-resources-test/project2/pom.xml
@@ -26,7 +26,6 @@ under the License.
     <version>1.0-SNAPSHOT</version>
   </parent>
   <artifactId>project2</artifactId>
-  <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>project2</name>
 </project>


### PR DESCRIPTION
When a test project `pom` has a parent, the `groupId`/`version` etc does not need to be duplicated when it can simply be inherited.