### PR TITLE
Remove (unused) `plexus-interactivity-api` dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -326,11 +326,6 @@ under the License.
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-interactivity-api</artifactId>
-      <version>1.5.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <version>3.0</version>


### PR DESCRIPTION
Maven reports that `plexus-interactivity-api` dependency is unused:
> [INFO] --- dependency:3.10.0:analyze (default-cli) @ maven-javadoc-plugin ---
[WARNING] Unused declared dependencies found:
{...}
[WARNING]    org.codehaus.plexus:plexus-interactivity-api:jar:1.5.1:compile

I can see no references in the codebase and the test suite passes without it.

It was added in https://github.com/apache/maven-javadoc-plugin/commit/7c3cba15183d491e53a08ac7e0b9fbff7873f970, although not clear why.