### PR TITLE
Pin maven-source-plugin in MJAVADOC-639 IT for Maven 4 compatibility

### DIFF
--- a/src/it/projects/MJAVADOC-639_requires_ignored/pom.xml
+++ b/src/it/projects/MJAVADOC-639_requires_ignored/pom.xml
@@ -50,6 +50,11 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>@project.version@</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.4.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/src/it/projects/MJAVADOC-639_requires_ignored/pom.xml
+++ b/src/it/projects/MJAVADOC-639_requires_ignored/pom.xml
@@ -53,7 +53,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>@version.maven-source-plugin@</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
## Summary

Follow-up to #1323 (cc @Bukama). PR #1323 enables `maven4-enabled: true` in the shared CI workflow and exposes 2 IT failures on every matrix cell. This PR addresses one of them — `MJAVADOC-639_requires_ignored`.

## Root cause

The `MJAVADOC-639_requires_ignored` IT POM does not pin `maven-source-plugin`'s version. Under Maven 4 the resolver picks the hard-coded default `4.0.0-beta-1`, which throws `NoSuchMethodError 'java.util.List org.apache.maven.api.services.ProjectManager.getCompileSourceRoots(...)'` against the current `org.apache.maven.api` shape.

Locally Maven `4.0.0-rc-5` masks this via a "Latest version of plugin ... failed compatibility check / Looking for compatible RELEASE version" fallback that selects `3.4.0`. CI (same `rc-5` binary) and `apache/maven` master snapshot (`4.1.0-SNAPSHOT`) both skip the fallback and execute `4.0.0-beta-1` directly — so the bug surfaces on PR #1323's CI matrix and will hit users on rc-6 / GA.

## Fix

Pin `maven-source-plugin` to `3.4.0` in the IT aggregator's `<pluginManagement>`. Mirrors the pattern landed for shade-plugin (`MSHADE-105` etc., PR #816).

## Out of scope

`MJAVADOC-338_downloadSources` also fails on PR #1323's CI (verify.groovy assertion on a `Downloading from mrm-maven-plugin: ...-sources.jar` log line that is missing on CI but present locally on both rc-5 and master snapshot). Not reproducible on macOS — needs a Linux-side reproduction of the MRM behaviour before a fix can be drafted. Tracked as a separate follow-up so this PR can land cleanly.

## Verification

- `mvn clean verify -P run-its -Dinvoker.test='MJAVADOC-639*'` with Maven `4.0.0-rc-5` on JDK 17.0.18 Temurin / macOS aarch64: 2/2 ITs pass (vs. 1/2 on `4.1.0-SNAPSHOT` master snapshot prior to the fix).

cc @Bukama @hboutemy
