### PR TITLE
fix ITs failing with Maven 4 from checksums

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@ under the License.
     <pluginPluginVersion>${version.maven-plugin-tools}</pluginPluginVersion>
     <jarPluginVersion>${version.maven-jar-plugin}</jarPluginVersion>
     <sitePluginVersion>${version.maven-site-plugin}</sitePluginVersion>
+    <surefirePluginVersion>${version.maven-surefire}</surefirePluginVersion>
     <toolchainPluginVersion>3.2.0</toolchainPluginVersion>
     <projectInfoReportsPluginVersion>${version.maven-project-info-reports-plugin}</projectInfoReportsPluginVersion>
     <project.build.outputTimestamp>2025-09-16T08:27:46Z</project.build.outputTimestamp>

--- a/src/it/projects/MJAVADOC-180/module1/pom.xml
+++ b/src/it/projects/MJAVADOC-180/module1/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.dbunit</groupId>
       <artifactId>dbunit</artifactId>
-      <version>2.2</version>
+      <version>2.8.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/it/projects/MJAVADOC-180/pom.xml
+++ b/src/it/projects/MJAVADOC-180/pom.xml
@@ -61,6 +61,11 @@
         <artifactId>maven-project-info-reports-plugin</artifactId>
         <version>@projectInfoReportsPluginVersion@</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>@surefirePluginVersion@</version>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/it/projects/dependencySource-2/MJAVADOC-280-2-distro/pom.xml
+++ b/src/it/projects/dependencySource-2/MJAVADOC-280-2-distro/pom.xml
@@ -70,5 +70,14 @@ under the License.
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>@surefirePluginVersion@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 </project>

--- a/src/it/projects/dependencySource-2/MJAVADOC-280-2-projects/pom.xml
+++ b/src/it/projects/dependencySource-2/MJAVADOC-280-2-projects/pom.xml
@@ -56,7 +56,7 @@ under the License.
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.0</version>
+          <version>@surefirePluginVersion@</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
no idea why it's not visible in #1323
but on my laptop, with Maven 4.0.0-RC5, I get

```
[INFO] -------------------------------------------------
[INFO] Build Summary:
[INFO]   Passed: 82, Failed: 2, Errors: 0, Skipped: 8
[INFO] -------------------------------------------------
[ERROR] The following builds failed:
[ERROR] *  dependencySource-2/pom.xml
[ERROR] *  MJAVADOC-180/pom.xml
[INFO] -------------------------------------------------
```

caused by 

```
Caused by: org.eclipse.aether.transfer.ArtifactTransferException:
  Could not transfer artifact junit:junit:pom:3.8.2 from/to mrm-maven-plugin (http://localhost:38373):
  Checksum validation failed, expected 'c735a15ca8fc2ea77db963c71ade153ffeb8212e  junit-3.8.2.pom'
  (REMOTE_INCLUDED) but is actually 'c735a15ca8fc2ea77db963c71ade153ffeb8212e'
```
see https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.pom.sha1

```
    Caused by: org.eclipse.aether.transfer.ChecksumFailureException:
      Checksum validation failed, expected 'a184d284ac11a8e93a71a502964a90c7aed469ea  /home/projects/maven/repository-staging/to-ibiblio/maven2/junit-addons/junit-addons/1.4/junit-addons-1.4.pom' (REMOTE_INCLUDED)
      but is actually 'a184d284ac11a8e93a71a502964a90c7aed469ea'
```
see https://repo.maven.apache.org/maven2/junit-addons/junit-addons/1.4/junit-addons-1.4.pom.sha1

and

```
Caused by: org.eclipse.aether.collection.DependencyCollectionException:
  Failed to collect dependencies at org.apache.maven.plugins:maven-surefire-plugin:jar:2.22.0 -> org.apache.maven.surefire:maven-surefire-common:jar:2.22.0 -> org.apache.maven:maven-core:jar:2.2.1 -> org.apache.maven.wagon:wagon-http:jar:1.0-beta-6 -> org.apache.maven.wagon:wagon-http-shared:jar:1.0-beta-6 -> commons-httpclient:commons-httpclient:jar:3.1 -> commons-codec:commons-codec:jar:1.2
...
                Caused by: org.eclipse.aether.transfer.ChecksumFailureException:
                  Checksum validation failed, expected '3924208ea1e84feb88701e9a5000bc65c66fb335  /home/projects/maven/repository-staging/to-ibiblio/maven2/commons-codec/commons-codec/1.2/commons-codec-1.2.pom' (REMOTE_INCLUDED)
                  but is actually '3924208ea1e84feb88701e9a5000bc65c66fb335'
```