### PR TITLE
Recurse into subdirs when determining staleness

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/StaleHelper.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/StaleHelper.java
@@ -20,13 +20,14 @@ package org.apache.maven.plugins.javadoc;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.maven.reporting.MavenReportException;
 import org.codehaus.plexus.util.cli.Commandline;
@@ -50,8 +51,10 @@ public class StaleHelper {
             List<String> options = new ArrayList<>();
             Path dir = cmd.getWorkingDirectory().toPath().toAbsolutePath().normalize();
             String[] args = cmd.getArguments();
+            // Add all the command arguments
             Collections.addAll(options, args);
 
+            // Add the contents of @-files
             for (String arg : args) {
                 if (arg.startsWith("@")) {
                     String name = arg.substring(1);
@@ -59,6 +62,7 @@ public class StaleHelper {
                     ignored.add(name);
                 }
             }
+            // Expand files and directories from the classpath and source path
             List<String> state = new ArrayList<>(options);
             boolean cp = false;
             boolean sp = false;
@@ -74,9 +78,7 @@ public class StaleHelper {
                     for (String ps : s.split(File.pathSeparator)) {
                         Path p = dir.resolve(ps);
                         for (Path c : walk(p)) {
-                            if (Files.isRegularFile(c)) {
-                                state.add(c + " = " + lastmod(c));
-                            }
+                            state.add(c + " = " + lastmod(c));
                         }
                         state.add(p + " = " + lastmod(p));
                     }
@@ -84,14 +86,16 @@ public class StaleHelper {
                 cp = "-classpath".equals(arg);
                 sp = "-sourcepath".equals(arg);
             }
+            // Add files from the working directory (i.e. where the javadocs
+            // are being written)
             for (Path p : walk(dir)) {
-                if (Files.isRegularFile(p) && !ignored.contains(p.getFileName().toString())) {
+                if (!ignored.contains(p.getFileName().toString())) {
                     state.add(p + " = " + lastmod(p));
                 }
             }
             return state;
         } catch (Exception e) {
-            throw new MavenReportException("Unable to compute stale date", e);
+            throw new MavenReportException("Unable to compute stale data", e);
         }
     }
 
@@ -111,14 +115,14 @@ public class StaleHelper {
             throw new MavenReportException("Error checking stale data", e);
         }
     }
-
+    /**
+     * Recursively find all regular files under the given root.
+     * @param dir the root directory
+     * @return a collection of paths
+     */
     private static Collection<Path> walk(Path dir) {
-        Collection<Path> paths = new ArrayList<>();
-        try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(dir)) {
-            for (Path p : directoryStream) {
-                paths.add(p);
-            }
-            return paths;
+        try (Stream<Path> stream = Files.walk(dir)) {
+            return stream.filter(Files::isRegularFile).collect(Collectors.toList());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
When the plugin checks if the goal is up-to-date or needs to run, it generates a file containing the options and the names+timestamps of all files in the source and target directories. It then compares this to the last-saved version to
determine if anything had changed. The generation did not recursively descend into the directories and therefore files could change without the plugin noticing that it needed to run.

Also added some comments to explain the existing code.

I did not add unit tests as the changed source file does not have a corresponding unit test files. I have run and tested this on Windows only.

This relates to issue #1324 

---

Following this checklist to help us incorporate your
contribution quickly and easily:

- [X] Your pull request should address just one issue, without pulling in other changes.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioural changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [X] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [X] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
