### PR TITLE
Clean up `MAVEN_ARGS` for IT configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -526,6 +526,8 @@ under the License.
               <environmentVariables>
                 <!-- required for MJAVADOC-538 -->
                 <_JAVA_OPTIONS>-Dabc=def</_JAVA_OPTIONS>
+                <!-- clen up the MAVEN_ARGS for the ITs -->
+                <MAVEN_ARGS />
               </environmentVariables>
             </configuration>
           </plugin>


### PR DESCRIPTION
Due to
https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#maven-transfer-progress-download-logs

`MJAVADOC-338_downloadSources` checks:

```
assert 1 == buildLog.readLines().count{it ==~ /\[INFO\] Downloading from mrm-maven-plugin\: .+\/mjavadoc338-direct-1\.0-sources\.jar/}

```