### PR TITLE
Fix incremental build losing output under excludedocfilessubdir

### DIFF
--- a/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
+++ b/src/main/java/org/apache/maven/plugins/javadoc/AbstractJavadocMojo.java
@@ -1937,12 +1937,6 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
         javadocOutputDirectory.mkdirs();
 
         // ----------------------------------------------------------------------
-        // Copy all resources
-        // ----------------------------------------------------------------------
-
-        copyAllResources(javadocOutputDirectory);
-
-        // ----------------------------------------------------------------------
         // Create command line for Javadoc
         // ----------------------------------------------------------------------
 
@@ -4971,12 +4965,17 @@ public abstract class AbstractJavadocMojo extends AbstractMojo {
      * @throws MavenReportException if any errors occur
      */
     private void executeJavadocCommandLine(Commandline cmd, File javadocOutputDirectory) throws MavenReportException {
+        // Resources must be copied only when Javadoc is actually (re)generated. copyAllResources removes
+        // excluded doc-file subdirectories from the output directory; if it ran while generation was skipped
+        // as up to date, those files would be deleted without being regenerated, leaving the output incomplete.
         if (staleDataPath != null) {
             if (!isUpToDate(cmd)) {
+                copyAllResources(javadocOutputDirectory);
                 doExecuteJavadocCommandLine(cmd, javadocOutputDirectory);
                 StaleHelper.writeStaleData(cmd, staleDataPath.toPath());
             }
         } else {
+            copyAllResources(javadocOutputDirectory);
             doExecuteJavadocCommandLine(cmd, javadocOutputDirectory);
         }
     }


### PR DESCRIPTION
When docfilessubdirs is enabled together with excludedocfilessubdir, an incremental build (re-run without a clean) could leave the excluded subdirectory's generated files missing from the output.

copyAllResources() removes the excluded doc-file subdirectories from the output directory before Javadoc runs, relying on Javadoc to regenerate them. However, the staleDataPath up-to-date check (enabled by default) skips the Javadoc invocation when the command line is unchanged, so on a second run the files were deleted but never regenerated.

Move the copyAllResources() call so it runs only when Javadoc is actually (re)generated. When the output is up to date, generation and resource copying are both skipped and the previous output is left intact.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [X] Your pull request should address just one issue, without pulling in other changes.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [X] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [X] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [X] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [X] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
